### PR TITLE
[issue20] Update the model path in model_inference.sh and update the port used by the test case

### DIFF
--- a/model-serving/model_inference.sh
+++ b/model-serving/model_inference.sh
@@ -18,4 +18,4 @@ echo "Model path: $MODEL_PATH"
 echo "Model name: $MODEL_NAME"
 echo "Pod container: $POD_CONTAINER"
 
-$POD_CONTAINER run --rm -it -p 8001:8001 -v $MODEL_PATH:/locallm/models:ro -e MODEL_PATH=models/$MODEL_NAME -e HOST=0.0.0.0 -e PORT=8001 -e MODEL_CHAT_FORMAT=openchat ghcr.io/abetlen/llama-cpp-python:latest 
+$POD_CONTAINER run --rm -it -p 8001:8001 -v $MODEL_PATH:/locallm/models:ro -e MODEL=/locallm/models/$MODEL_NAME -e HOST=0.0.0.0 -e PORT=8001 -e MODEL_CHAT_FORMAT=openchat ghcr.io/abetlen/llama-cpp-python:latest

--- a/tests/wiseagents/llm/test_LangChainWiseAgentRemoteLLM.py
+++ b/tests/wiseagents/llm/test_LangChainWiseAgentRemoteLLM.py
@@ -2,6 +2,6 @@ import pytest
 from wiseagents.llm.LangChainWiseAgentRemoteLLM import LangChainWiseAgentRemoteLLM
 
 def test_method1():
-        agent = LangChainWiseAgentRemoteLLM("Answer my greeting saying Hello and my name", "Phi-3-mini-4k-instruct-q4.gguf","http://localhost:8000")
+        agent = LangChainWiseAgentRemoteLLM("Answer my greeting saying Hello and my name", "Phi-3-mini-4k-instruct-q4.gguf","http://localhost:8001")
         response = agent.process("Hello my name is Stefano")
         assert response.content.startswith(" Hi Stefano!")


### PR DESCRIPTION
Closes https://github.com/fjuma/wise-agents/issues/20

Needed to use `-e MODEL` instead of `-e MODEL_PATH` and also needed to update its value to `/locallm/models/$MODEL_NAME`.

Also updated the port used by the test to match the port used in `model_inference.sh`.