### PR TITLE
Better concurrency check

### DIFF
--- a/.github/workflows/build-and-test-workflow-run.yml
+++ b/.github/workflows/build-and-test-workflow-run.yml
@@ -13,7 +13,7 @@ permissions:
 
 # Only run the latest job
 concurrency:
-  group: '${{ github.workflow }} @ ${{ github.ref || github.run_id }}'
+  group: '${{ github.workflow }} - ${{ github.event.workflow_run.event }}: ${{ github.event.workflow_run.head_repository.full_name }}@${{ github.event.workflow_run.head_branch }}'
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
I found that the existing concurrency check caused the workflow_run jobs for PRs opened at the same time to cancel each other.
This changes the group to have a more descriptive string of what actually is being tested to improve on this.

A push to the main branch of kabir/wise-agents will now be identified as `Build and Test Workflow Run - push: kabir/wise-agents@main'`. Further pushes to this main branch will stop previous jobs.

A push to a pull request branch will be identified as `Build and Test Workflow Run - pull_request: kabir-test/wise-agents@test_pr3`. `kabir-test/wiseagents` is the repository/fork from where the PR is opened, and `test_pr3` is the branch containing the changes.

I believe this should be sufficient to allow pull requests in parallel, while aborting currently running jobs against the same branch, and have made sure it works the way I intend with manual testing.