### PR TITLE
Fixing issue #253 so that all containers have a name and are started …

### DIFF
--- a/artemis/artemis.sh
+++ b/artemis/artemis.sh
@@ -9,10 +9,16 @@ export POD_CONTAINER="${POD_CONTAINER:-docker}"
 # The .env file should be in the same directory as the script
 # Rename the .env.example file to .env and set the environment variables
 WORKING_DIR="$(dirname "${BASH_SOURCE[0]}")"
+if [ -f $WORKING_DIR/../.env ]; then
+	echo "Executing " $WORKING_DIR/../.env
+	. $WORKING_DIR/../.env
+fi
 if [ -f $WORKING_DIR/.env ]; then
+	echo "Executing " $WORKING_DIR/.env
 	. $WORKING_DIR/.env
 fi
 
+
 echo "Pod container: $POD_CONTAINER"
 
-$POD_CONTAINER run --rm --name artemis -p 61616:61616 -p 8161:8161 --rm apache/activemq-artemis:latest-alpine
+$POD_CONTAINER run --rm ${EXTRA_CONTAINER_OPTION} --name artemis -p 61616:61616 -p 8161:8161 apache/activemq-artemis:latest-alpine

--- a/graphdb/run_graphdb.sh
+++ b/graphdb/run_graphdb.sh
@@ -11,8 +11,13 @@ export NEO4J_DATABASE="${NEO4J_DATABASE:-neo4j}"
 # The .env file should be in the same directory as the script
 # Rename the .env.example file to .env and set the environment variables
 WORKING_DIR="$(dirname "${BASH_SOURCE[0]}")"
+if [ -f $WORKING_DIR/../.env ]; then
+	echo "Executing " $WORKING_DIR/../.env
+	. $WORKING_DIR/../.env
+fi
 if [ -f $WORKING_DIR/.env ]; then
-       . $WORKING_DIR/.env
+	echo "Executing " $WORKING_DIR/.env
+	. $WORKING_DIR/.env
 fi
 
 echo "Neo4j Username: $NEO4J_USERNAME"
@@ -20,4 +25,4 @@ echo "Neo4j Password: $NEO4J_PASSWORD"
 echo "Neo4j Database: $NEO4J_DATABASE"
 echo "Pod container: $POD_CONTAINER"
 
-$POD_CONTAINER run --name neo4j --restart always --publish=7474:7474 --publish=7687:7687 --env NEO4J_AUTH=$NEO4J_USERNAME/$NEO4J_PASSWORD -e NEO4J_PLUGINS=\[\"apoc\"\] neo4j:5.21.0
+$POD_CONTAINER run --rm ${EXTRA_CONTAINER_OPTION} --name neo4j --publish=7474:7474 --publish=7687:7687 -e NEO4J_AUTH=$NEO4J_USERNAME/$NEO4J_PASSWORD -e NEO4J_PLUGINS=\[\"apoc\"\] neo4j:5.21.0

--- a/model-serving/model_inference.sh
+++ b/model-serving/model_inference.sh
@@ -14,9 +14,13 @@ export MODEL_PATH="${MODEL_PATH:-./granite-7b-lab-GGUF}"
 # The .env file should be in the same directory as the script
 # Rename the .env.example file to .env and set the environment variables
 WORKING_DIR="$(dirname "${BASH_SOURCE[0]}")"
+if [ -f $WORKING_DIR/../.env ]; then
+	echo "Executing " $WORKING_DIR/../.env
+	. $WORKING_DIR/../.env
+fi
 if [ -f $WORKING_DIR/.env ]; then
-       echo "Executing .env file"
-       . $WORKING_DIR/.env
+	echo "Executing " $WORKING_DIR/.env
+	. $WORKING_DIR/.env
 fi
 
 $POD_CONTAINER volume ls | grep $MODEL_VOLUME
@@ -39,4 +43,4 @@ $POD_CONTAINER container create --name dummy -v $VOLUME_PATH:/root hello-world
 $POD_CONTAINER cp  $MODEL_PATH/$MODEL_NAME dummy:/root/$MODEL_NAME
 $POD_CONTAINER rm dummy
 
-$POD_CONTAINER run --rm -it -p 8001:8001 -v $MODEL_VOLUME:/locallm/models:ro -e MODEL=/locallm/models/$MODEL_NAME -e HOST=$LLM_BIND_ADDRESS -e PORT=8001 -e MODEL_CHAT_FORMAT=openchat ghcr.io/abetlen/llama-cpp-python:latest
+$POD_CONTAINER run --rm ${EXTRA_CONTAINER_OPTION} --name llama-cpp -it -p 8001:8001 -v $MODEL_VOLUME:/locallm/models:ro -e MODEL=/locallm/models/$MODEL_NAME -e HOST=$LLM_BIND_ADDRESS -e PORT=8001 -e MODEL_CHAT_FORMAT=openchat ghcr.io/abetlen/llama-cpp-python:latest

--- a/vectordb/run_vectordb.sh
+++ b/vectordb/run_vectordb.sh
@@ -10,10 +10,17 @@ export POSTGRES_DB="${POSTGRES_DB:-postgres}"
 # If a .env file is present, it will read the environment variables from there
 # The .env file should be in the same directory as the script
 # Rename the .env.example file to .env and set the environment variables
-if [ -f ./.env ]; then
-	. ./.env
+WORKING_DIR="$(dirname "${BASH_SOURCE[0]}")"
+if [ -f $WORKING_DIR/../.env ]; then
+	echo "Executing " $WORKING_DIR/../.env
+	. $WORKING_DIR/../.env
 fi
+if [ -f $WORKING_DIR/.env ]; then
+	echo "Executing " $WORKING_DIR/.env
+	. $WORKING_DIR/.env
+fi
+
 
 echo "Pod container: $POD_CONTAINER"
 
-$POD_CONTAINER run --rm --name vectordb -e POSTGRES_USER=$POSTGRES_USER -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD -e POSTGRES_DB=$POSTGRES_DB -p 6024:5432 -d pgvector/pgvector:pg16
+$POD_CONTAINER run --rm ${EXTRA_CONTAINER_OPTION} --name vectordb -e POSTGRES_USER=$POSTGRES_USER -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD -e POSTGRES_DB=$POSTGRES_DB -p 6024:5432 pgvector/pgvector:pg16


### PR DESCRIPTION
…with "-rm" and not in daemon mode.

Updating scripts to support .env file in the parent directory and overloading with the .env file in the current directory

All containers have a name and are started with "-rm" and not in daemon mode

Issue: #253