### PR TITLE
Use the tag to force env var substitution in quoted values #279

### DIFF
--- a/src/wiseagents/yaml_env/yaml_utils.py
+++ b/src/wiseagents/yaml_env/yaml_utils.py
@@ -55,6 +55,6 @@ def setup_yaml_for_env_vars():
     In the second example, '${PORT:80}', we are doing the same but looking up `os.getenv("PORT"). In this case,
     if the 'PORT' environment variable is not set, it will use the default value shows, which in this case is '80'.
     """
-    yaml.add_implicit_resolver("!pathex", _env_pattern)
-    yaml.add_constructor("!pathex", _env_constructor)
+    yaml.add_implicit_resolver("!env_var", _env_pattern)
+    yaml.add_constructor("!env_var", _env_constructor)
 

--- a/tests/wiseagents/yaml_env/test_yaml_env.py
+++ b/tests/wiseagents/yaml_env/test_yaml_env.py
@@ -94,6 +94,8 @@ def test_data_types_sanity():
         falseTitleCase: False
         falseUpperCase: FALSE
         string: hello world
+        intString: "1"
+        floatString: "1.1"
         array:
         - first
         - second
@@ -120,6 +122,10 @@ def test_data_types_sanity():
     assert type(test_values["falseUpperCase"]) == bool
     assert test_values["string"] == "hello world"
     assert type(test_values["string"]) == str
+    assert test_values["intString"] == "1"
+    assert type(test_values["intString"]) == str
+    assert test_values["floatString"] == "1.1"
+    assert type(test_values["floatString"]) == str
     assert len(test_values["array"]) == 2
     assert type(test_values["array"]) == list
     assert test_values["array"][0] == "first"
@@ -147,6 +153,9 @@ def test_data_types_when_replaced_by_env_var(monkeypatch):
         string_with_number_and_boolean: Hello ${INT} ${TRUE_TITLE_CASE}
         two_numbers: ${INT}${INT}
         two_numbers_float: ${INT}.${INT}
+        intString: !env_var "${INT}"
+        floatString: !env_var "${INT}.${INT}"
+
     """
 
     monkeypatch.setenv("INT", "1")
@@ -184,6 +193,12 @@ def test_data_types_when_replaced_by_env_var(monkeypatch):
     assert type(test_values["two_numbers"]) == int
     assert test_values["two_numbers_float"] == 1.1
     assert type(test_values["two_numbers_float"]) == float
+    # TODO Should be 1 and 1.1 as strings - see https://github.com/wise-agents/wise-agents/issues/280
+    assert test_values["intString"] == 1
+    assert type(test_values["intString"]) == int
+    assert test_values["floatString"] == 1.1
+    assert type(test_values["floatString"]) == float
+
 
 
 def test_data_types_when_replaced_by_env_var_default():
@@ -202,6 +217,9 @@ def test_data_types_when_replaced_by_env_var_default():
         string_with_number_and_boolean: Hello ${INT:1} ${TRUE_TITLE_CASE:True}
         two_numbers: ${INT:1}${INT:1}
         two_numbers_float: ${INT:1}.${INT:2}
+        intString: !env_var "${INT:1}"
+        floatString: !env_var "${INT:1}.${INT:1}"
+
     """
 
     test_values = yaml.load(input, loader)["test"]
@@ -229,3 +247,8 @@ def test_data_types_when_replaced_by_env_var_default():
     assert type(test_values["two_numbers"]) == int
     assert test_values["two_numbers_float"] == 1.2
     assert type(test_values["two_numbers_float"]) == float
+    # TODO Should be 1 and 1.1 as strings - see https://github.com/wise-agents/wise-agents/issues/280
+    assert test_values["intString"] == 1
+    assert type(test_values["intString"]) == int
+    assert test_values["floatString"] == 1.1
+    assert type(test_values["floatString"]) == float


### PR DESCRIPTION
Fixes #279

Note that the values are the wrong type now, which will be addressed by #280, or when we get to validating