### PR TITLE
Maeste/issue195

### DIFF
--- a/src/wiseagents/cli/wise_agent_cli.py
+++ b/src/wiseagents/cli/wise_agent_cli.py
@@ -37,7 +37,7 @@ def main():
         if  (user_input == '/exit' or user_input == '/x'):
             #stop all agents
             for agent in agent_list:
-                agent.stopAgent()
+                agent.stop_agent()
             sys.exit(0)
         if (user_input == '/load-agents' or user_input == '/l'):
             file_path = input("Enter the file path (ENTER for default src/wiseagents/cli/test-multiple.yaml): ")
@@ -51,7 +51,7 @@ def main():
                         if agent.name == "PassThroughClientAgent1":
                             _passThroughClientAgent1 = agent
                             _passThroughClientAgent1.set_response_delivery(response_delivered)
-                        agent.startAgent()
+                        agent.start_agent()
                         agent_list.append(agent)
                 except yaml.YAMLError as exc:
                     print(exc)

--- a/src/wiseagents/cli/wise_agent_cli.py
+++ b/src/wiseagents/cli/wise_agent_cli.py
@@ -49,7 +49,7 @@ def main():
                         agent.startAgent()
                 except yaml.YAMLError as exc:
                     print(exc)
-                print(f"registered agents= {WiseAgentRegistry.get_agents()}")
+                print(f"registered agents= {WiseAgentRegistry.get_agents_descptions_dict()}")
         if  (user_input == '/chat' or user_input == '/c'):
             while True:
                 user_input = input("Enter a message (or /back): ")
@@ -59,12 +59,12 @@ def main():
                     _passThroughClientAgent1.send_request(WiseAgentMessage(user_input, "PassThroughClientAgent1"), "LLMOnlyWiseAgent2")
                     cond.wait()
         if (user_input == '/agents' or user_input == '/a'):
-            print(f"registered agents= {WiseAgentRegistry.get_agents()}")
+            print(f"registered agents= {WiseAgentRegistry.get_agents_descptions_dict()}")
 
         if (user_input == '/send' or user_input == '/s'):
             agent_name = input("Enter the agent name: ")
             message = input("Enter the message: ")
-            agent : WiseAgent = WiseAgentRegistry.get_agent(agent_name)
+            agent : WiseAgent = WiseAgentRegistry.get_agent_description(agent_name)
             if agent:
                 with cond:
                     _passThroughClientAgent1.send_request(WiseAgentMessage(message, "PassThroughClientAgent1"), agent_name)

--- a/src/wiseagents/cli/wise_agent_cli.py
+++ b/src/wiseagents/cli/wise_agent_cli.py
@@ -1,5 +1,6 @@
 import sys
 import threading
+from typing import List
 
 import yaml
 
@@ -18,6 +19,7 @@ def response_delivered(message: WiseAgentMessage):
 
 
 def main():
+    agent_list : List[WiseAgent]= []
     while True:
         user_input = input("wise-agents (/help for available command): ")
         if  (user_input == '/help' or user_input == '/h'):
@@ -33,6 +35,9 @@ def main():
             for msg in WiseAgentRegistry.get_or_create_context('default').message_trace:
                 print(msg)
         if  (user_input == '/exit' or user_input == '/x'):
+            #stop all agents
+            for agent in agent_list:
+                agent.stopAgent()
             sys.exit(0)
         if (user_input == '/load-agents' or user_input == '/l'):
             file_path = input("Enter the file path (ENTER for default src/wiseagents/cli/test-multiple.yaml): ")
@@ -47,9 +52,10 @@ def main():
                             _passThroughClientAgent1 = agent
                             _passThroughClientAgent1.set_response_delivery(response_delivered)
                         agent.startAgent()
+                        agent_list.append(agent)
                 except yaml.YAMLError as exc:
                     print(exc)
-                print(f"registered agents= {WiseAgentRegistry.get_agents_descptions_dict()}")
+                print(f"registered agents= {WiseAgentRegistry.fetch_agents_descriptions_dict()}")
         if  (user_input == '/chat' or user_input == '/c'):
             while True:
                 user_input = input("Enter a message (or /back): ")
@@ -59,7 +65,7 @@ def main():
                     _passThroughClientAgent1.send_request(WiseAgentMessage(user_input, "PassThroughClientAgent1"), "LLMOnlyWiseAgent2")
                     cond.wait()
         if (user_input == '/agents' or user_input == '/a'):
-            print(f"registered agents= {WiseAgentRegistry.get_agents_descptions_dict()}")
+            print(f"registered agents= {WiseAgentRegistry.fetch_agents_descriptions_dict()}")
 
         if (user_input == '/send' or user_input == '/s'):
             agent_name = input("Enter the agent name: ")

--- a/src/wiseagents/core.py
+++ b/src/wiseagents/core.py
@@ -68,7 +68,7 @@ class WiseAgent(yaml.YAMLObject):
     def stopAgent(self):
         ''' Stop the agent by stopping the transport and removing the agent from the registry.'''
         self.transport.stop()
-        WiseAgentRegistry.remove_agent(self.name)
+        WiseAgentRegistry.unregister_agent(self.name)
     
     def __repr__(self):
         '''Return a string representation of the agent.'''
@@ -963,7 +963,7 @@ class WiseAgentRegistry:
     """
     A Registry to get available agents and running contexts
     """
-    agents : dict[str, str] = {}
+    agents_descriptions_dict : dict[str, str] = {}
     contexts : dict[str, WiseAgentContext] = {}
     tools: dict[str, WiseAgentTool] = {}
     
@@ -1027,7 +1027,7 @@ class WiseAgentRegistry:
         if (cls.get_config().get("use_redis") == True):
             cls.redis_db.hset("agents", key=agent_name, value=agent_description)
         else:
-            cls.agents[agent_name] = agent_description
+            cls.agents_descriptions_dict[agent_name] = agent_description
     @classmethod    
     def register_context(cls, context : WiseAgentContext):
         """
@@ -1038,14 +1038,14 @@ class WiseAgentRegistry:
         else:
             cls.contexts[context.name] = context
     @classmethod    
-    def get_agents(cls) -> dict [str, str]:
+    def get_agents_descptions_dict(cls) -> dict [str, str]:
         """
-        Get the list of agents
+        Get the dict with the agent names as keys and descriptions as values
         """
         if (cls.get_config().get("use_redis") == True):
             return cls.redis_db.hgetall("agents")
         else:
-            return cls.agents
+            return cls.agents_descriptions_dict
     
     @classmethod
     def get_contexts(cls) -> dict [str, WiseAgentContext]:
@@ -1062,9 +1062,9 @@ class WiseAgentRegistry:
             return cls.contexts
     
     @classmethod
-    def get_agent(cls, agent_name: str) -> str:
+    def get_agent_description(cls, agent_name: str) -> str:
         """
-        Get the agent with the given name
+        Get the agent description for the agent with the given name
         """
         if (cls.get_config().get("use_redis") == True):
             return_byte = cls.redis_db.hget("agents", key=agent_name)
@@ -1073,7 +1073,7 @@ class WiseAgentRegistry:
             else:  
                 return None
         else:
-            return cls.agents.get(agent_name) 
+            return cls.agents_descriptions_dict.get(agent_name) 
     
     @classmethod
     def get_or_create_context(cls, context_name: str) -> WiseAgentContext:
@@ -1107,14 +1107,14 @@ class WiseAgentRegistry:
                 return True
     
     @classmethod
-    def remove_agent(cls, agent_name: str):
+    def unregister_agent(cls, agent_name: str):
         """
-        Remove the agent from the registry
+        Unregister the agent from the registry
         """
         if (cls.get_config().get("use_redis") == True):
             cls.redis_db.hdel("agents", agent_name)
         else:
-            cls.agents.pop(agent_name)
+            cls.agents_descriptions_dict.pop(agent_name)
         
     @classmethod
     def remove_context(cls, context_name: str):
@@ -1127,14 +1127,14 @@ class WiseAgentRegistry:
             cls.contexts.pop(context_name)
     
     @classmethod
-    def clear_agents(cls):
+    def clear_agents_descriptions_dict(cls):
         """
         Clear all agents from the registry
         """
         if (cls.get_config().get("use_redis") == True):
             cls.redis_db.delete("agents")
         else:
-            cls.agents.clear()
+            cls.agents_descriptions_dict.clear()
     
     @classmethod
     def clear_contexts(cls):
@@ -1194,7 +1194,7 @@ class WiseAgentRegistry:
             List[str]: the list of agent descriptions
         """
         agent_descriptions = []
-        for agent_name, agent_description in cls.get_agents().items():
+        for agent_name, agent_description in cls.get_agents_descptions_dict().items():
             agent_descriptions.append(f"Agent Name: {agent_name} Agent Description: {agent_description}")
 
         return agent_descriptions

--- a/src/wiseagents/core.py
+++ b/src/wiseagents/core.py
@@ -57,15 +57,15 @@ class WiseAgent(yaml.YAMLObject):
         self._graph_db = graph_db
         self._transport = transport
         self._system_message = system_message
-        self.startAgent()
+        self.start_agent()
         
-    def startAgent(self):
+    def start_agent(self):
         ''' Start the agent by setting the call backs and starting the transport.'''
         self.transport.set_call_backs(self.process_request, self.process_event, self.process_error, self.process_response)
         self.transport.start()
         WiseAgentRegistry.register_agent(self.name, self.description) 
     
-    def stopAgent(self):
+    def stop_agent(self):
         ''' Stop the agent by stopping the transport and removing the agent from the registry.'''
         self.transport.stop()
         WiseAgentRegistry.unregister_agent(self.name)

--- a/tests/wiseagents/agents/test_challenger.py
+++ b/tests/wiseagents/agents/test_challenger.py
@@ -46,7 +46,7 @@ def run_after_all_tests():
     reset_env_variable("STOMP_USER", original_stomp_user)
     reset_env_variable("STOMP_PASSWORD", original_stomp_password)
     
-    WiseAgentRegistry.clear_agents()
+    WiseAgentRegistry.clear_agents_descriptions_dict()
     WiseAgentRegistry.clear_contexts()
 
 
@@ -105,6 +105,6 @@ def test_cove_challenger():
         cond.wait()
         if assertError is not None:
             raise assertError
-        print(f"registered agents= {WiseAgentRegistry.get_agents()}")
+        print(f"registered agents= {WiseAgentRegistry.get_agents_descptions_dict()}")
         for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
             print(f'{message.sender} : {message.message} ')

--- a/tests/wiseagents/agents/test_challenger.py
+++ b/tests/wiseagents/agents/test_challenger.py
@@ -79,7 +79,6 @@ def response_delivered(message: WiseAgentMessage):
         cond.notify()
 
 
-@pytest.mark.needsllama
 def test_cove_challenger():
     global assertError
     groq_api_key = os.getenv("GROQ_API_KEY")

--- a/tests/wiseagents/agents/test_challenger.py
+++ b/tests/wiseagents/agents/test_challenger.py
@@ -46,8 +46,8 @@ def run_after_all_tests():
     reset_env_variable("STOMP_USER", original_stomp_user)
     reset_env_variable("STOMP_PASSWORD", original_stomp_password)
     
-    WiseAgentRegistry.clear_agents_descriptions_dict()
-    WiseAgentRegistry.clear_contexts()
+    
+    
 
 
 def set_env_variable(env_variable: str, value: str) -> str:
@@ -80,30 +80,35 @@ def response_delivered(message: WiseAgentMessage):
 
 
 def test_cove_challenger():
-    global assertError
-    groq_api_key = os.getenv("GROQ_API_KEY")
-    
-    pg_vector_db = PGVectorLangChainWiseAgentVectorDB(get_connection_string())
-    llm1 = OpenaiAPIWiseAgentLLM(system_message="You are a retrieval augmented chatbot. You answer users' questions based on the context provided by the user. If you can't answer the question using the given context, just say you don't know the answer.",
-                                 model_name="llama-3.1-70b-versatile", remote_address="https://api.groq.com/openai/v1",
-                                 api_key=groq_api_key)
-    agent = CoVeChallengerRAGWiseAgent(name="ChallengerWiseAgent1", description="This is a test agent", llm=llm1, vector_db=pg_vector_db,
-                              transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="ChallengerWiseAgent1"),
-                                       k=2, num_verification_questions=2)
+    try:
+        global assertError
+        groq_api_key = os.getenv("GROQ_API_KEY")
+        
+        pg_vector_db = PGVectorLangChainWiseAgentVectorDB(get_connection_string())
+        llm1 = OpenaiAPIWiseAgentLLM(system_message="You are a retrieval augmented chatbot. You answer users' questions based on the context provided by the user. If you can't answer the question using the given context, just say you don't know the answer.",
+                                    model_name="llama-3.1-70b-versatile", remote_address="https://api.groq.com/openai/v1",
+                                    api_key=groq_api_key)
+        agent = CoVeChallengerRAGWiseAgent(name="ChallengerWiseAgent1", description="This is a test agent", llm=llm1, vector_db=pg_vector_db,
+                                transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="ChallengerWiseAgent1"),
+                                        k=2, num_verification_questions=2)
 
-    with cond:
-        client_agent1 = PassThroughClientAgent(name="PassThroughClientAgent1", description="This is a test agent",
-                                               transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="PassThroughClientAgent1")
-                                               )
-        client_agent1.set_response_delivery(response_delivered)
-        client_agent1.send_request(WiseAgentMessage(f"{{'question': 'How many medals did Biles win at the Winter Olympics in 2024?'\n"
-                                                    f"  'response': 'Biles won 4 medals.'\n"
-                                                    f"}}",
-                                                    "PassThroughClientAgent1"),
-                                   "ChallengerWiseAgent1")
-        cond.wait()
-        if assertError is not None:
-            raise assertError
-        print(f"registered agents= {WiseAgentRegistry.get_agents_descptions_dict()}")
-        for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
-            print(f'{message.sender} : {message.message} ')
+        with cond:
+            client_agent1 = PassThroughClientAgent(name="PassThroughClientAgent1", description="This is a test agent",
+                                                transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="PassThroughClientAgent1")
+                                                )
+            client_agent1.set_response_delivery(response_delivered)
+            client_agent1.send_request(WiseAgentMessage(f"{{'question': 'How many medals did Biles win at the Winter Olympics in 2024?'\n"
+                                                        f"  'response': 'Biles won 4 medals.'\n"
+                                                        f"}}",
+                                                        "PassThroughClientAgent1"),
+                                    "ChallengerWiseAgent1")
+            cond.wait()
+            if assertError is not None:
+                raise assertError
+            print(f"registered agents= {WiseAgentRegistry.fetch_agents_descriptions_dict()}")
+            for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
+                print(f'{message.sender} : {message.message} ')
+    finally:        
+        #stopping the agents
+        client_agent1.stopAgent()
+        agent.stopAgent()

--- a/tests/wiseagents/agents/test_challenger.py
+++ b/tests/wiseagents/agents/test_challenger.py
@@ -110,5 +110,5 @@ def test_cove_challenger():
                 print(f'{message.sender} : {message.message} ')
     finally:        
         #stopping the agents
-        client_agent1.stopAgent()
-        agent.stopAgent()
+        client_agent1.stop_agent()
+        agent.stop_agent()

--- a/tests/wiseagents/agents/test_phased_coordinator.py
+++ b/tests/wiseagents/agents/test_phased_coordinator.py
@@ -87,9 +87,9 @@ def test_phased_coordinator():
                 print(f'{message.sender} : {message.message} ')
     finally:
         #stop agents
-        client_agent1.stopAgent()
-        agent1.stopAgent()
-        agent2.stopAgent()
-        agent3.stopAgent()
-        agent4.stopAgent()
-        agent5.stopAgent()
+        client_agent1.stop_agent()
+        agent1.stop_agent()
+        agent2.stop_agent()
+        agent3.stop_agent()
+        agent4.stop_agent()
+        agent5.stop_agent()

--- a/tests/wiseagents/agents/test_phased_coordinator.py
+++ b/tests/wiseagents/agents/test_phased_coordinator.py
@@ -14,7 +14,7 @@ cond = threading.Condition()
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
     yield
-    WiseAgentRegistry.clear_agents()
+    WiseAgentRegistry.clear_agents_descriptions_dict()
     WiseAgentRegistry.clear_contexts()
 
 def final_response_delivered(message: WiseAgentMessage):
@@ -81,6 +81,6 @@ def test_phased_coordinator():
                                    "Coordinator")
         cond.wait()
 
-        print(f"registered agents= {WiseAgentRegistry.get_agents()}")
+        print(f"registered agents= {WiseAgentRegistry.get_agents_descptions_dict()}")
         for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
             print(f'{message.sender} : {message.message} ')

--- a/tests/wiseagents/agents/test_phased_coordinator.py
+++ b/tests/wiseagents/agents/test_phased_coordinator.py
@@ -14,8 +14,8 @@ cond = threading.Condition()
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
     yield
-    WiseAgentRegistry.clear_agents_descriptions_dict()
-    WiseAgentRegistry.clear_contexts()
+    
+    
 
 def final_response_delivered(message: WiseAgentMessage):
     with cond:
@@ -29,58 +29,67 @@ def test_phased_coordinator():
     """
     Requires STOMP_USER, STOMP_PASSWORD, and a Groq API_KEY.
     """
-    groq_api_key = os.getenv("GROQ_API_KEY")
+    try:
+        groq_api_key = os.getenv("GROQ_API_KEY")
 
-    llm = OpenaiAPIWiseAgentLLM(system_message="You are a helpful assistant.",
-                                model_name="llama-3.1-70b-versatile",
-                                remote_address="https://api.groq.com/openai/v1",
-                                api_key=groq_api_key)
+        llm = OpenaiAPIWiseAgentLLM(system_message="You are a helpful assistant.",
+                                    model_name="llama-3.1-70b-versatile",
+                                    remote_address="https://api.groq.com/openai/v1",
+                                    api_key=groq_api_key)
 
-    agent1 = PhasedCoordinatorWiseAgent(name="Coordinator", description="This is a coordinator agent", llm=llm,
-                                  transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="Coordinator"),
-                                  phases=["Information Gathering", "Verification of Information", "Analysis"],
-                                  system_message="You will be coordinating a group of agents to solve a problem.",
-                                  max_iterations=2)
+        agent1 = PhasedCoordinatorWiseAgent(name="Coordinator", description="This is a coordinator agent", llm=llm,
+                                    transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="Coordinator"),
+                                    phases=["Information Gathering", "Verification of Information", "Analysis"],
+                                    system_message="You will be coordinating a group of agents to solve a problem.",
+                                    max_iterations=2)
 
-    agent2 = CollaboratorWiseAgent(name="Agent2", description="This agent provides information about error messages using Source1", llm=llm,
-                                   transport=StompWiseAgentTransport(host='localhost', port=61616,
-                                                                     agent_name="Agent2"),
-                                   system_message="You are a helpful assistant that will provide information about the given error message")
+        agent2 = CollaboratorWiseAgent(name="Agent2", description="This agent provides information about error messages using Source1", llm=llm,
+                                    transport=StompWiseAgentTransport(host='localhost', port=61616,
+                                                                        agent_name="Agent2"),
+                                    system_message="You are a helpful assistant that will provide information about the given error message")
 
-    agent3 = CollaboratorWiseAgent(name="Agent3", description="This agent provides information about error messages using Source2",
-                                   llm=llm,
-                                   transport=StompWiseAgentTransport(host='localhost', port=61616,
-                                                                     agent_name="Agent3"),
-                                   system_message="You are a helpful assistant that will provide information about the given error message")
+        agent3 = CollaboratorWiseAgent(name="Agent3", description="This agent provides information about error messages using Source2",
+                                    llm=llm,
+                                    transport=StompWiseAgentTransport(host='localhost', port=61616,
+                                                                        agent_name="Agent3"),
+                                    system_message="You are a helpful assistant that will provide information about the given error message")
 
-    agent4 = CollaboratorWiseAgent(name="Agent4",
-                                   description="This agent describes the underlying cause of a problem given information about the problem. This agent" +
-                                               " should be called after getting information about the problem using Agent2 or Agent3.",
-                                   llm=llm,
-                                   transport=StompWiseAgentTransport(host='localhost', port=61616,
-                                                                     agent_name="Agent4"),
-                                   system_message="You are a helpful assistant that will determine the underlying cause of a problem given information about the problem")
+        agent4 = CollaboratorWiseAgent(name="Agent4",
+                                    description="This agent describes the underlying cause of a problem given information about the problem. This agent" +
+                                                " should be called after getting information about the problem using Agent2 or Agent3.",
+                                    llm=llm,
+                                    transport=StompWiseAgentTransport(host='localhost', port=61616,
+                                                                        agent_name="Agent4"),
+                                    system_message="You are a helpful assistant that will determine the underlying cause of a problem given information about the problem")
 
-    agent5 = CollaboratorWiseAgent(name="Agent5",
-                                   description="This agent is used to verify if the information provided by other agents is accurate. This " +
-                                               "agent should be called after getting information about a problem using Agent2 or Agent3. This agent " +
-                                               "should be called before calling Agent4.",
-                                   llm=llm,
-                                   transport=StompWiseAgentTransport(host='localhost', port=61616,
-                                                                     agent_name="Agent5"),
-                                   system_message="You will determine if the information provided by other agents is accurate.")
+        agent5 = CollaboratorWiseAgent(name="Agent5",
+                                    description="This agent is used to verify if the information provided by other agents is accurate. This " +
+                                                "agent should be called after getting information about a problem using Agent2 or Agent3. This agent " +
+                                                "should be called before calling Agent4.",
+                                    llm=llm,
+                                    transport=StompWiseAgentTransport(host='localhost', port=61616,
+                                                                        agent_name="Agent5"),
+                                    system_message="You will determine if the information provided by other agents is accurate.")
 
-    with cond:
-        client_agent1 = PassThroughClientAgent(name="PassThroughClientAgent1", description="This is a test agent",
-                                               transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="PassThroughClientAgent1")
-                                               )
-        client_agent1.set_response_delivery(final_response_delivered)
-        client_agent1.send_request(WiseAgentMessage("How do I prevent the following exception from occurring:"
-                                                    "Exception Details: java.lang.NullPointerException at com.example.ExampleApp.processData(ExampleApp.java:47)", 
-                                                    "PassThroughClientAgent1"),
-                                   "Coordinator")
-        cond.wait()
+        with cond:
+            client_agent1 = PassThroughClientAgent(name="PassThroughClientAgent1", description="This is a test agent",
+                                                transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="PassThroughClientAgent1")
+                                                )
+            client_agent1.set_response_delivery(final_response_delivered)
+            client_agent1.send_request(WiseAgentMessage("How do I prevent the following exception from occurring:"
+                                                        "Exception Details: java.lang.NullPointerException at com.example.ExampleApp.processData(ExampleApp.java:47)", 
+                                                        "PassThroughClientAgent1"),
+                                    "Coordinator")
+            cond.wait()
 
-        print(f"registered agents= {WiseAgentRegistry.get_agents_descptions_dict()}")
-        for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
-            print(f'{message.sender} : {message.message} ')
+            print(f"registered agents= {WiseAgentRegistry.fetch_agents_descriptions_dict()}")
+            for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
+                print(f'{message.sender} : {message.message} ')
+    finally:
+        #stop agents
+        client_agent1.stopAgent()
+        agent1.stopAgent()
+        agent2.stopAgent()
+        agent3.stopAgent()
+        agent4.stopAgent()
+        agent5.stopAgent()

--- a/tests/wiseagents/agents/test_sequential_coordinator.py
+++ b/tests/wiseagents/agents/test_sequential_coordinator.py
@@ -16,7 +16,7 @@ assertError : AssertionError = None
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
     yield
-    WiseAgentRegistry.clear_agents()
+    WiseAgentRegistry.clear_agents_descriptions_dict()
     WiseAgentRegistry.clear_contexts()
 
 def response_delivered(message: WiseAgentMessage):
@@ -68,6 +68,6 @@ def test_sequential_coordinator():
         if assertError is not None:
             logging.info(f"assertion failed")
             raise assertError
-        print(f"registered agents= {WiseAgentRegistry.get_agents()}")
+        print(f"registered agents= {WiseAgentRegistry.get_agents_descptions_dict()}")
         for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
             print(f'{message.sender} : {message.message} ')

--- a/tests/wiseagents/agents/test_sequential_coordinator.py
+++ b/tests/wiseagents/agents/test_sequential_coordinator.py
@@ -74,8 +74,8 @@ def test_sequential_coordinator():
                 print(f'{message.sender} : {message.message} ')
     finally:
         #stop all agents
-        client_agent1.stopAgent()
-        agent1.stopAgent()
-        agent2.stopAgent()
-        coordinator.stopAgent()
+        client_agent1.stop_agent()
+        agent1.stop_agent()
+        agent2.stop_agent()
+        coordinator.stop_agent()
 

--- a/tests/wiseagents/agents/test_sequential_coordinator.py
+++ b/tests/wiseagents/agents/test_sequential_coordinator.py
@@ -16,8 +16,8 @@ assertError : AssertionError = None
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
     yield
-    WiseAgentRegistry.clear_agents_descriptions_dict()
-    WiseAgentRegistry.clear_contexts()
+    
+    
 
 def response_delivered(message: WiseAgentMessage):
     global assertError
@@ -38,36 +38,44 @@ def test_sequential_coordinator():
     """
     Requires STOMP_USER and STOMP_PASSWORD.
     """
-    global assertError
-    groq_api_key = os.getenv("GROQ_API_KEY")
-    
-    llm1 = OpenaiAPIWiseAgentLLM(system_message="Your name is Agent1. Answer my greeting saying Hello and my name and tell me your name.",
-                                 model_name="llama-3.1-70b-versatile", remote_address="https://api.groq.com/openai/v1",
-                                 api_key=groq_api_key)
-    agent1 = LLMOnlyWiseAgent(name="Agent1", description="This is a test agent", llm=llm1,
-                              transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="Agent1"))
+    try:
+        global assertError
+        groq_api_key = os.getenv("GROQ_API_KEY")
+        
+        llm1 = OpenaiAPIWiseAgentLLM(system_message="Your name is Agent1. Answer my greeting saying Hello and my name and tell me your name.",
+                                    model_name="llama-3.1-70b-versatile", remote_address="https://api.groq.com/openai/v1",
+                                    api_key=groq_api_key)
+        agent1 = LLMOnlyWiseAgent(name="Agent1", description="This is a test agent", llm=llm1,
+                                transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="Agent1"))
 
-    llm2 = OpenaiAPIWiseAgentLLM(system_message="Your name is Agent2. Answer my greeting saying Hello and include all agent names from the given message and tell me your name.",
-                                 model_name="llama-3.1-70b-versatile", remote_address="https://api.groq.com/openai/v1",
-                                 api_key=groq_api_key)
-    agent2 = LLMOnlyWiseAgent(name="Agent2", description="This is a test agent", llm=llm2,
-                              transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="Agent2"))
+        llm2 = OpenaiAPIWiseAgentLLM(system_message="Your name is Agent2. Answer my greeting saying Hello and include all agent names from the given message and tell me your name.",
+                                    model_name="llama-3.1-70b-versatile", remote_address="https://api.groq.com/openai/v1",
+                                    api_key=groq_api_key)
+        agent2 = LLMOnlyWiseAgent(name="Agent2", description="This is a test agent", llm=llm2,
+                                transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="Agent2"))
 
-    coordinator = SequentialCoordinatorWiseAgent(name="SequentialCoordinator", description="This is a coordinator agent",
-                                                 transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="SequentialCoordinator"),
-                                                 agents=["Agent1", "Agent2"])
+        coordinator = SequentialCoordinatorWiseAgent(name="SequentialCoordinator", description="This is a coordinator agent",
+                                                    transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="SequentialCoordinator"),
+                                                    agents=["Agent1", "Agent2"])
 
-    with cond:
-        client_agent1 = PassThroughClientAgent(name="PassThroughClientAgent1", description="This is a test agent",
-                                               transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="PassThroughClientAgent1")
-                                               )
-        client_agent1.set_response_delivery(response_delivered)
-        client_agent1.send_request(WiseAgentMessage("My name is Agent0", "PassThroughClientAgent1"),
-                                   "SequentialCoordinator")
-        cond.wait()
-        if assertError is not None:
-            logging.info(f"assertion failed")
-            raise assertError
-        print(f"registered agents= {WiseAgentRegistry.get_agents_descptions_dict()}")
-        for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
-            print(f'{message.sender} : {message.message} ')
+        with cond:
+            client_agent1 = PassThroughClientAgent(name="PassThroughClientAgent1", description="This is a test agent",
+                                                transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="PassThroughClientAgent1")
+                                                )
+            client_agent1.set_response_delivery(response_delivered)
+            client_agent1.send_request(WiseAgentMessage("My name is Agent0", "PassThroughClientAgent1"),
+                                    "SequentialCoordinator")
+            cond.wait()
+            if assertError is not None:
+                logging.info(f"assertion failed")
+                raise assertError
+            print(f"registered agents= {WiseAgentRegistry.fetch_agents_descriptions_dict()}")
+            for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
+                print(f'{message.sender} : {message.message} ')
+    finally:
+        #stop all agents
+        client_agent1.stopAgent()
+        agent1.stopAgent()
+        agent2.stopAgent()
+        coordinator.stopAgent()
+

--- a/tests/wiseagents/agents/test_tools.py
+++ b/tests/wiseagents/agents/test_tools.py
@@ -14,8 +14,8 @@ from wiseagents.transports.stomp import StompWiseAgentTransport
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
     yield
-    WiseAgentRegistry.clear_agents_descriptions_dict()
-    WiseAgentRegistry.clear_contexts()
+    
+    
 
 
 cond = threading.Condition()
@@ -90,93 +90,94 @@ class WiseAgentWeather(WiseAgent):
 
 @pytest.mark.needsllm
 def test_agent_tool():
-    json_schema = {
-                    "type": "object",
-                    "properties": {
-                        "location": {
-                            "type": "string",
-                            "description": "The city and state, e.g. San Francisco, CA",
+    try:
+        json_schema = {
+                        "type": "object",
+                        "properties": {
+                            "location": {
+                                "type": "string",
+                                "description": "The city and state, e.g. San Francisco, CA",
+                            },
+                            "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
                         },
-                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
-                    },
-                    "required": ["location"],
-                    }
-    WiseAgentTool(name="WeatherAgent", description="Get the current weather in a given location", agent_tool=True,
-                 parameters_json_schema=json_schema, call_back=None) 
-    llm = OpenaiAPIWiseAgentLLM(system_message="Answer my greeting saying Hello and my name",
-                                         model_name="llama3.1",
-                                         remote_address="http://localhost:11434/v1")      
-    
-    weather_agent = WiseAgentWeather(name="WeatherAgent", description="Get the current weather in a given location")
-    weather_agent.startAgent()
-    
-    agent = LLMWiseAgentWithTools(name="WiseIntelligentAgent",
-                                 description="This is a test agent",
-                                 llm=llm,
-                                 tools = ["WeatherAgent"],
-                                 transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="WiseIntelligentAgent")
-                                 )
-    agent.startAgent() 
-   
-    logging.info(f"tool: {WiseAgentRegistry.get_tool('WeatherAgent').get_tool_OpenAI_format()}")
-    with cond:    
-
-        client_agent1  = PassThroughClientAgent(name="PassThroughClientAgent1", description="This is a test agent",
-                                                transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="PassThroughClientAgent1")
-                                                )
-        client_agent1.set_response_delivery(response_delivered)
-        client_agent1.send_request(WiseAgentMessage("What is the current weather in Tokyo?", "PassThroughClientAgent1"), 
-                                                    "WiseIntelligentAgent")
-        cond.wait()
+                        "required": ["location"],
+                        }
+        WiseAgentTool(name="WeatherAgent", description="Get the current weather in a given location", agent_tool=True,
+                    parameters_json_schema=json_schema, call_back=None) 
+        llm = OpenaiAPIWiseAgentLLM(system_message="Answer my greeting saying Hello and my name",
+                                            model_name="llama3.1",
+                                            remote_address="http://localhost:11434/v1")      
         
+        weather_agent = WiseAgentWeather(name="WeatherAgent", description="Get the current weather in a given location")
+        
+        agent = LLMWiseAgentWithTools(name="WiseIntelligentAgent",
+                                    description="This is a test agent",
+                                    llm=llm,
+                                    tools = ["WeatherAgent"],
+                                    transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="WiseIntelligentAgent")
+                                    )
+    
+        logging.info(f"tool: {WiseAgentRegistry.get_tool('WeatherAgent').get_tool_OpenAI_format()}")
+        with cond:    
 
-    logging.info(f"registered agents= {WiseAgentRegistry.get_agents_descptions_dict()}")
-    for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
-        logging.info(f'{message.sender} : {message.message} ')
-    client_agent1.stopAgent()
-    agent.stopAgent()
-    weather_agent.stopAgent()
+            client_agent1  = PassThroughClientAgent(name="PassThroughClientAgent1", description="This is a test agent",
+                                                    transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="PassThroughClientAgent1")
+                                                    )
+            client_agent1.set_response_delivery(response_delivered)
+            client_agent1.send_request(WiseAgentMessage("What is the current weather in Tokyo?", "PassThroughClientAgent1"), 
+                                                        "WiseIntelligentAgent")
+            cond.wait()
+            
+
+        logging.info(f"registered agents= {WiseAgentRegistry.fetch_agents_descriptions_dict()}")
+        for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
+            logging.info(f'{message.sender} : {message.message} ')
+        client_agent1.stopAgent()
+    finally:    
+        agent.stopAgent()
+        weather_agent.stopAgent()
     
 @pytest.mark.needsllm
 def test_tool():
-    json_schema = {
-                    "type": "object",
-                    "properties": {
-                        "location": {
-                            "type": "string",
-                            "description": "The city and state, e.g. San Francisco, CA",
+    try:
+        json_schema = {
+                        "type": "object",
+                        "properties": {
+                            "location": {
+                                "type": "string",
+                                "description": "The city and state, e.g. San Francisco, CA",
+                            },
+                            "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
                         },
-                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
-                    },
-                    "required": ["location"],
-                    }
-    WiseAgentTool(name="get_current_weather", description="Get the current weather in a given location", agent_tool=False,
-                 parameters_json_schema=json_schema, call_back=get_current_weather) 
-    llm = OpenaiAPIWiseAgentLLM(system_message="Answer my greeting saying Hello and my name",
-                                         model_name="llama3.1",
-                                         remote_address="http://localhost:11434/v1")      
-    agent = LLMWiseAgentWithTools(name="WiseIntelligentAgent",
-                                 description="This is a test agent",
-                                 llm=llm,
-                                 tools = ["get_current_weather"],
-                                 transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="WiseIntelligentAgent")
-                                 )
-    agent.startAgent() 
-   
-    logging.info(f"tool: {WiseAgentRegistry.get_tool('get_current_weather').get_tool_OpenAI_format()}")
-    with cond:    
+                        "required": ["location"],
+                        }
+        WiseAgentTool(name="get_current_weather", description="Get the current weather in a given location", agent_tool=False,
+                    parameters_json_schema=json_schema, call_back=get_current_weather) 
+        llm = OpenaiAPIWiseAgentLLM(system_message="Answer my greeting saying Hello and my name",
+                                            model_name="llama3.1",
+                                            remote_address="http://localhost:11434/v1")      
+        agent = LLMWiseAgentWithTools(name="WiseIntelligentAgent",
+                                    description="This is a test agent",
+                                    llm=llm,
+                                    tools = ["get_current_weather"],
+                                    transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="WiseIntelligentAgent")
+                                    )
+    
+        logging.info(f"tool: {WiseAgentRegistry.get_tool('get_current_weather').get_tool_OpenAI_format()}")
+        with cond:    
 
-        client_agent1  = PassThroughClientAgent(name="PassThroughClientAgent1", description="This is a test agent",
-                                                transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="PassThroughClientAgent1")
-                                                )
-        client_agent1.set_response_delivery(response_delivered)
-        client_agent1.send_request(WiseAgentMessage("What is the current weather in Tokyo?", "PassThroughClientAgent1"), 
-                                                    "WiseIntelligentAgent")
-        cond.wait()
-        
+            client_agent1  = PassThroughClientAgent(name="PassThroughClientAgent1", description="This is a test agent",
+                                                    transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="PassThroughClientAgent1")
+                                                    )
+            client_agent1.set_response_delivery(response_delivered)
+            client_agent1.send_request(WiseAgentMessage("What is the current weather in Tokyo?", "PassThroughClientAgent1"), 
+                                                        "WiseIntelligentAgent")
+            cond.wait()
+            
 
-    logging.info(f"registered agents= {WiseAgentRegistry.get_agents_descptions_dict()}")
-    for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
-        logging.info(f'{message.sender} : {message.message} ')
-    client_agent1.stopAgent()
-    agent.stopAgent()
+        logging.info(f"registered agents= {WiseAgentRegistry.fetch_agents_descriptions_dict()}")
+        for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
+            logging.info(f'{message.sender} : {message.message} ')
+    finally:
+        client_agent1.stopAgent()
+        agent.stopAgent()

--- a/tests/wiseagents/agents/test_tools.py
+++ b/tests/wiseagents/agents/test_tools.py
@@ -14,7 +14,7 @@ from wiseagents.transports.stomp import StompWiseAgentTransport
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
     yield
-    WiseAgentRegistry.clear_agents()
+    WiseAgentRegistry.clear_agents_descriptions_dict()
     WiseAgentRegistry.clear_contexts()
 
 
@@ -132,7 +132,7 @@ def test_agent_tool():
         cond.wait()
         
 
-    logging.info(f"registered agents= {WiseAgentRegistry.get_agents()}")
+    logging.info(f"registered agents= {WiseAgentRegistry.get_agents_descptions_dict()}")
     for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
         logging.info(f'{message.sender} : {message.message} ')
     client_agent1.stopAgent()
@@ -179,7 +179,7 @@ def test_tool():
         cond.wait()
         
 
-    logging.info(f"registered agents= {WiseAgentRegistry.get_agents()}")
+    logging.info(f"registered agents= {WiseAgentRegistry.get_agents_descptions_dict()}")
     for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
         logging.info(f'{message.sender} : {message.message} ')
     client_agent1.stopAgent()

--- a/tests/wiseagents/agents/test_tools.py
+++ b/tests/wiseagents/agents/test_tools.py
@@ -39,7 +39,7 @@ def response_delivered(message: WiseAgentMessage):
     with cond: 
         response = message.message
         msg = response
-        assert "degree" in msg 
+        assert "22" in msg 
         print(f"C Response delivered: {msg}")
         cond.notify()
 
@@ -132,10 +132,10 @@ def test_agent_tool():
         logging.info(f"registered agents= {WiseAgentRegistry.fetch_agents_descriptions_dict()}")
         for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
             logging.info(f'{message.sender} : {message.message} ')
-        client_agent1.stopAgent()
-    finally:    
-        agent.stopAgent()
-        weather_agent.stopAgent()
+    finally:
+        client_agent1.stop_agent()    
+        agent.stop_agent()
+        weather_agent.stop_agent()
     
 @pytest.mark.needsllm
 def test_tool():
@@ -179,5 +179,5 @@ def test_tool():
         for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
             logging.info(f'{message.sender} : {message.message} ')
     finally:
-        client_agent1.stopAgent()
-        agent.stopAgent()
+        client_agent1.stop_agent()
+        agent.stop_agent()

--- a/tests/wiseagents/agents/test_tools.py
+++ b/tests/wiseagents/agents/test_tools.py
@@ -88,7 +88,7 @@ class WiseAgentWeather(WiseAgent):
 #Install ollam from their official website https://ollama.com/
 #run ollama with the following command: ollama run llama3.1
 
-@pytest.mark.needsllama
+@pytest.mark.needsllm
 def test_agent_tool():
     json_schema = {
                     "type": "object",
@@ -103,11 +103,9 @@ def test_agent_tool():
                     }
     WiseAgentTool(name="WeatherAgent", description="Get the current weather in a given location", agent_tool=True,
                  parameters_json_schema=json_schema, call_back=None) 
-    groq_api_key = os.getenv("GROQ_API_KEY")
-    
     llm = OpenaiAPIWiseAgentLLM(system_message="Answer my greeting saying Hello and my name",
-                                         model_name="llama-3.1-70b-versatile", remote_address="https://api.groq.com/openai/v1",
-                                         api_key=groq_api_key)      
+                                         model_name="llama3.1",
+                                         remote_address="http://localhost:11434/v1")      
     
     weather_agent = WiseAgentWeather(name="WeatherAgent", description="Get the current weather in a given location")
     weather_agent.startAgent()
@@ -139,7 +137,7 @@ def test_agent_tool():
     agent.stopAgent()
     weather_agent.stopAgent()
     
-@pytest.mark.needsllama
+@pytest.mark.needsllm
 def test_tool():
     json_schema = {
                     "type": "object",
@@ -154,11 +152,9 @@ def test_tool():
                     }
     WiseAgentTool(name="get_current_weather", description="Get the current weather in a given location", agent_tool=False,
                  parameters_json_schema=json_schema, call_back=get_current_weather) 
-    groq_api_key = os.getenv("GROQ_API_KEY")
-    
     llm = OpenaiAPIWiseAgentLLM(system_message="Answer my greeting saying Hello and my name",
-                                         model_name="llama-3.1-70b-versatile", remote_address="https://api.groq.com/openai/v1",
-                                         api_key=groq_api_key)      
+                                         model_name="llama3.1",
+                                         remote_address="http://localhost:11434/v1")      
     agent = LLMWiseAgentWithTools(name="WiseIntelligentAgent",
                                  description="This is a test agent",
                                  llm=llm,
@@ -184,4 +180,3 @@ def test_tool():
         logging.info(f'{message.sender} : {message.message} ')
     client_agent1.stopAgent()
     agent.stopAgent()
-   

--- a/tests/wiseagents/agents/test_tools_fakeLLM.py
+++ b/tests/wiseagents/agents/test_tools_fakeLLM.py
@@ -15,8 +15,8 @@ from wiseagents.transports.stomp import StompWiseAgentTransport
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
     yield
-    WiseAgentRegistry.clear_agents_descriptions_dict()
-    WiseAgentRegistry.clear_contexts()
+    
+    
 class FakeOpenaiAPIWiseAgentLLM(WiseAgentRemoteLLM):
     
     client = None
@@ -113,7 +113,6 @@ def test_tool():
                                  tools = ["get_current_weather"],
                                  transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="WiseIntelligentAgent")
                                  )
-   agent.startAgent() 
    
    logging.info(f"tool: {WiseAgentRegistry.get_tool('get_current_weather').get_tool_OpenAI_format()}")
    with cond:    
@@ -127,7 +126,7 @@ def test_tool():
         cond.wait()
         
 
-   logging.info(f"registered agents= {WiseAgentRegistry.get_agents_descptions_dict()}")
+   logging.info(f"registered agents= {WiseAgentRegistry.fetch_agents_descriptions_dict()}")
    for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
        logging.info(f'{message.sender} : {message.message} ')
    

--- a/tests/wiseagents/agents/test_tools_fakeLLM.py
+++ b/tests/wiseagents/agents/test_tools_fakeLLM.py
@@ -15,7 +15,7 @@ from wiseagents.transports.stomp import StompWiseAgentTransport
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
     yield
-    WiseAgentRegistry.clear_agents()
+    WiseAgentRegistry.clear_agents_descriptions_dict()
     WiseAgentRegistry.clear_contexts()
 class FakeOpenaiAPIWiseAgentLLM(WiseAgentRemoteLLM):
     
@@ -127,7 +127,7 @@ def test_tool():
         cond.wait()
         
 
-   logging.info(f"registered agents= {WiseAgentRegistry.get_agents()}")
+   logging.info(f"registered agents= {WiseAgentRegistry.get_agents_descptions_dict()}")
    for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
        logging.info(f'{message.sender} : {message.message} ')
    

--- a/tests/wiseagents/agents/test_tools_groq.py
+++ b/tests/wiseagents/agents/test_tools_groq.py
@@ -138,7 +138,7 @@ def test_agent_tool():
     agent.stopAgent()
     weather_agent.stopAgent()
 
-@pytest.mark.needsllm
+
 def test_tool():
     json_schema = {
                     "type": "object",
@@ -153,9 +153,11 @@ def test_tool():
                     }
     WiseAgentTool(name="get_current_weather", description="Get the current weather in a given location", agent_tool=False,
                  parameters_json_schema=json_schema, call_back=get_current_weather) 
+    groq_api_key = os.getenv("GROQ_API_KEY")
+    
     llm = OpenaiAPIWiseAgentLLM(system_message="Answer my greeting saying Hello and my name",
-                                         model_name="llama3.1",
-                                         remote_address="http://localhost:11434/v1")      
+                                         model_name="llama-3.1-70b-versatile", remote_address="https://api.groq.com/openai/v1",
+                                         api_key=groq_api_key)      
     agent = LLMWiseAgentWithTools(name="WiseIntelligentAgent",
                                  description="This is a test agent",
                                  llm=llm,
@@ -181,4 +183,5 @@ def test_tool():
         logging.info(f'{message.sender} : {message.message} ')
     client_agent1.stopAgent()
     agent.stopAgent()
+   
     

--- a/tests/wiseagents/agents/test_tools_groq.py
+++ b/tests/wiseagents/agents/test_tools_groq.py
@@ -133,9 +133,9 @@ def test_agent_tool():
         for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
             logging.info(f'{message.sender} : {message.message} ')
     finally:
-        client_agent1.stopAgent()
-        agent.stopAgent()
-        weather_agent.stopAgent()
+        client_agent1.stop_agent()
+        agent.stop_agent()
+        weather_agent.stop_agent()
 
 
 def test_tool():
@@ -181,7 +181,7 @@ def test_tool():
         for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
             logging.info(f'{message.sender} : {message.message} ')
     finally:
-        client_agent1.stopAgent()
-        agent.stopAgent()
+        client_agent1.stop_agent()
+        agent.stop_agent()
    
     

--- a/tests/wiseagents/agents/test_tools_groq.py
+++ b/tests/wiseagents/agents/test_tools_groq.py
@@ -14,7 +14,7 @@ from wiseagents.transports.stomp import StompWiseAgentTransport
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
     yield
-    WiseAgentRegistry.clear_agents()
+    WiseAgentRegistry.clear_agents_descriptions_dict()
     WiseAgentRegistry.clear_contexts()
 
 cond = threading.Condition()
@@ -131,7 +131,7 @@ def test_agent_tool():
         cond.wait()
         
 
-    logging.info(f"registered agents= {WiseAgentRegistry.get_agents()}")
+    logging.info(f"registered agents= {WiseAgentRegistry.get_agents_descptions_dict()}")
     for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
         logging.info(f'{message.sender} : {message.message} ')
     client_agent1.stopAgent()
@@ -176,7 +176,7 @@ def test_tool():
         cond.wait()
         
 
-    logging.info(f"registered agents= {WiseAgentRegistry.get_agents()}")
+    logging.info(f"registered agents= {WiseAgentRegistry.get_agents_descptions_dict()}")
     for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
         logging.info(f'{message.sender} : {message.message} ')
     client_agent1.stopAgent()

--- a/tests/wiseagents/agents/test_tools_groq.py
+++ b/tests/wiseagents/agents/test_tools_groq.py
@@ -14,8 +14,8 @@ from wiseagents.transports.stomp import StompWiseAgentTransport
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
     yield
-    WiseAgentRegistry.clear_agents_descriptions_dict()
-    WiseAgentRegistry.clear_contexts()
+    
+    
 
 cond = threading.Condition()
 def get_current_weather(location, unit="fahrenheit"):
@@ -89,99 +89,99 @@ class WiseAgentWeather(WiseAgent):
 #You need to set the environment variable GROQ_API_KEY with the value of your OpenAI API key
 #get your GROQ API key from https://groq.com/ and set it in the environment variable GROQ_API_KEY
 def test_agent_tool():
-    json_schema = {
-                    "type": "object",
-                    "properties": {
-                        "location": {
-                            "type": "string",
-                            "description": "The city and state, e.g. San Francisco, CA",
+    try:    
+        json_schema = {
+                        "type": "object",
+                        "properties": {
+                            "location": {
+                                "type": "string",
+                                "description": "The city and state, e.g. San Francisco, CA",
+                            },
+                            "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
                         },
-                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
-                    },
-                    "required": ["location"],
-                    }
-    WiseAgentTool(name="WeatherAgent", description="Get the current weather in a given location", agent_tool=True,
-                 parameters_json_schema=json_schema, call_back=None) 
-    groq_api_key= os.getenv("GROQ_API_KEY")
-    assert groq_api_key is not None
-    llm = OpenaiAPIWiseAgentLLM(system_message="Answer my greeting saying Hello and my name",
-                                         model_name="llama-3.1-70b-versatile",
-                                         remote_address="https://api.groq.com/openai/v1",
-                                         api_key=groq_api_key)      
-    
-    weather_agent = WiseAgentWeather(name="WeatherAgent", description="Get the current weather in a given location")
-    weather_agent.startAgent()
-    agent = LLMWiseAgentWithTools(name="WiseIntelligentAgent",
-                                 description="This is a test agent",
-                                 llm=llm,
-                                 tools = ["WeatherAgent"],
-                                 transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="WiseIntelligentAgent")
-                                 )
-    agent.startAgent() 
-   
-    logging.info(f"tool: {WiseAgentRegistry.get_tool('WeatherAgent').get_tool_OpenAI_format()}")
-    with cond:    
-
-        client_agent1  = PassThroughClientAgent(name="PassThroughClientAgent1", description="This is a test agent",
-                                                transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="PassThroughClientAgent1")
-                                                )
-        client_agent1.set_response_delivery(response_delivered)
-        client_agent1.send_request(WiseAgentMessage("What is the current weather in Tokyo?", "PassThroughClientAgent1"), 
-                                                    "WiseIntelligentAgent")
-        cond.wait()
+                        "required": ["location"],
+                        }
+        WiseAgentTool(name="WeatherAgent", description="Get the current weather in a given location", agent_tool=True,
+                    parameters_json_schema=json_schema, call_back=None) 
+        groq_api_key= os.getenv("GROQ_API_KEY")
+        assert groq_api_key is not None
+        llm = OpenaiAPIWiseAgentLLM(system_message="Answer my greeting saying Hello and my name",
+                                            model_name="llama-3.1-70b-versatile",
+                                            remote_address="https://api.groq.com/openai/v1",
+                                            api_key=groq_api_key)      
         
+        weather_agent = WiseAgentWeather(name="WeatherAgent", description="Get the current weather in a given location")
+        agent = LLMWiseAgentWithTools(name="WiseIntelligentAgent",
+                                    description="This is a test agent",
+                                    llm=llm,
+                                    tools = ["WeatherAgent"],
+                                    transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="WiseIntelligentAgent")
+                                    )
+        logging.info(f"tool: {WiseAgentRegistry.get_tool('WeatherAgent').get_tool_OpenAI_format()}")
+        with cond:    
 
-    logging.info(f"registered agents= {WiseAgentRegistry.get_agents_descptions_dict()}")
-    for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
-        logging.info(f'{message.sender} : {message.message} ')
-    client_agent1.stopAgent()
-    agent.stopAgent()
-    weather_agent.stopAgent()
+            client_agent1  = PassThroughClientAgent(name="PassThroughClientAgent1", description="This is a test agent",
+                                                    transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="PassThroughClientAgent1")
+                                                    )
+            client_agent1.set_response_delivery(response_delivered)
+            client_agent1.send_request(WiseAgentMessage("What is the current weather in Tokyo?", "PassThroughClientAgent1"), 
+                                                        "WiseIntelligentAgent")
+            cond.wait()
+            
+
+        logging.info(f"registered agents= {WiseAgentRegistry.fetch_agents_descriptions_dict()}")
+        for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
+            logging.info(f'{message.sender} : {message.message} ')
+    finally:
+        client_agent1.stopAgent()
+        agent.stopAgent()
+        weather_agent.stopAgent()
 
 
 def test_tool():
-    json_schema = {
-                    "type": "object",
-                    "properties": {
-                        "location": {
-                            "type": "string",
-                            "description": "The city and state, e.g. San Francisco, CA",
+    try:
+        json_schema = {
+                        "type": "object",
+                        "properties": {
+                            "location": {
+                                "type": "string",
+                                "description": "The city and state, e.g. San Francisco, CA",
+                            },
+                            "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
                         },
-                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
-                    },
-                    "required": ["location"],
-                    }
-    WiseAgentTool(name="get_current_weather", description="Get the current weather in a given location", agent_tool=False,
-                 parameters_json_schema=json_schema, call_back=get_current_weather) 
-    groq_api_key = os.getenv("GROQ_API_KEY")
-    
-    llm = OpenaiAPIWiseAgentLLM(system_message="Answer my greeting saying Hello and my name",
-                                         model_name="llama-3.1-70b-versatile", remote_address="https://api.groq.com/openai/v1",
-                                         api_key=groq_api_key)      
-    agent = LLMWiseAgentWithTools(name="WiseIntelligentAgent",
-                                 description="This is a test agent",
-                                 llm=llm,
-                                 tools = ["get_current_weather"],
-                                 transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="WiseIntelligentAgent")
-                                 )
-    agent.startAgent() 
-   
-    logging.info(f"tool: {WiseAgentRegistry.get_tool('get_current_weather').get_tool_OpenAI_format()}")
-    with cond:    
-
-        client_agent1  = PassThroughClientAgent(name="PassThroughClientAgent1", description="This is a test agent",
-                                                transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="PassThroughClientAgent1")
-                                                )
-        client_agent1.set_response_delivery(response_delivered)
-        client_agent1.send_request(WiseAgentMessage("What is the current weather in Tokyo?", "PassThroughClientAgent1"), 
-                                                    "WiseIntelligentAgent")
-        cond.wait()
+                        "required": ["location"],
+                        }
+        WiseAgentTool(name="get_current_weather", description="Get the current weather in a given location", agent_tool=False,
+                    parameters_json_schema=json_schema, call_back=get_current_weather) 
+        groq_api_key = os.getenv("GROQ_API_KEY")
         
+        llm = OpenaiAPIWiseAgentLLM(system_message="Answer my greeting saying Hello and my name",
+                                            model_name="llama-3.1-70b-versatile", remote_address="https://api.groq.com/openai/v1",
+                                            api_key=groq_api_key)      
+        agent = LLMWiseAgentWithTools(name="WiseIntelligentAgent",
+                                    description="This is a test agent",
+                                    llm=llm,
+                                    tools = ["get_current_weather"],
+                                    transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="WiseIntelligentAgent")
+                                    )
+        
+        logging.info(f"tool: {WiseAgentRegistry.get_tool('get_current_weather').get_tool_OpenAI_format()}")
+        with cond:    
 
-    logging.info(f"registered agents= {WiseAgentRegistry.get_agents_descptions_dict()}")
-    for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
-        logging.info(f'{message.sender} : {message.message} ')
-    client_agent1.stopAgent()
-    agent.stopAgent()
+            client_agent1  = PassThroughClientAgent(name="PassThroughClientAgent1", description="This is a test agent",
+                                                    transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="PassThroughClientAgent1")
+                                                    )
+            client_agent1.set_response_delivery(response_delivered)
+            client_agent1.send_request(WiseAgentMessage("What is the current weather in Tokyo?", "PassThroughClientAgent1"), 
+                                                        "WiseIntelligentAgent")
+            cond.wait()
+            
+
+        logging.info(f"registered agents= {WiseAgentRegistry.fetch_agents_descriptions_dict()}")
+        for message in WiseAgentRegistry.get_or_create_context('default').message_trace:
+            logging.info(f'{message.sender} : {message.message} ')
+    finally:
+        client_agent1.stopAgent()
+        agent.stopAgent()
    
     

--- a/tests/wiseagents/cli/test_WiseAgentCli.py
+++ b/tests/wiseagents/cli/test_WiseAgentCli.py
@@ -68,7 +68,7 @@ def run_after_all_tests():
     reset_env_variable("NEO4J_USERNAME", original_neo4j_username)
     reset_env_variable("NEO4J_PASSWORD", original_neo4j_password)
     
-    WiseAgentRegistry.clear_agents()
+    WiseAgentRegistry.clear_agents_descriptions_dict()
     WiseAgentRegistry.clear_contexts()
 
 def set_env_variable(env_variable: str, value: str) -> str:

--- a/tests/wiseagents/cli/test_WiseAgentCli.py
+++ b/tests/wiseagents/cli/test_WiseAgentCli.py
@@ -68,8 +68,8 @@ def run_after_all_tests():
     reset_env_variable("NEO4J_USERNAME", original_neo4j_username)
     reset_env_variable("NEO4J_PASSWORD", original_neo4j_password)
     
-    WiseAgentRegistry.clear_agents_descriptions_dict()
-    WiseAgentRegistry.clear_contexts()
+    
+    
 
 def set_env_variable(env_variable: str, value: str) -> str:
     original_value = os.environ.get(env_variable)

--- a/tests/wiseagents/graphdb/test_Neo4jLangChainWiseAgentGraphDB.py
+++ b/tests/wiseagents/graphdb/test_Neo4jLangChainWiseAgentGraphDB.py
@@ -93,6 +93,7 @@ def test_insert_graph_documents_and_query(monkeypatch):
         assert "Ontario" in documents[0].content
     finally:
         graph_db.close()
+        
 
 
 def test_insert_entity_and_query(monkeypatch):

--- a/tests/wiseagents/llm/test_WiseAgentRemoteLLM.py
+++ b/tests/wiseagents/llm/test_WiseAgentRemoteLLM.py
@@ -7,7 +7,7 @@ from wiseagents.llm import OpenaiAPIWiseAgentLLM
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
     yield
-    WiseAgentRegistry.clear_agents()
+    WiseAgentRegistry.clear_agents_descriptions_dict()
     WiseAgentRegistry.clear_contexts()
 
 @pytest.mark.needsllm

--- a/tests/wiseagents/llm/test_WiseAgentRemoteLLM.py
+++ b/tests/wiseagents/llm/test_WiseAgentRemoteLLM.py
@@ -7,11 +7,12 @@ from wiseagents.llm import OpenaiAPIWiseAgentLLM
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
     yield
-    WiseAgentRegistry.clear_agents_descriptions_dict()
-    WiseAgentRegistry.clear_contexts()
+    
+    
 
 @pytest.mark.needsllm
 def test_openai():
         agent = OpenaiAPIWiseAgentLLM("Answer my greeting saying Hello and my name", "Phi-3-mini-4k-instruct-q4.gguf","http://localhost:8001/v1")
         response = agent.process_single_prompt("Hello my name is Stefano")
         assert "Stefano" in response.content
+

--- a/tests/wiseagents/test-multiple.yaml
+++ b/tests/wiseagents/test-multiple.yaml
@@ -15,6 +15,10 @@ _name: Agent1
 _vector_db: !PGVectorLangChainWiseAgentVectorDB
   _connection_string: postgresql+psycopg://langchain:langchain@localhost:6024/langchain
   _embedding_model_name: all-MiniLM-L6-v2
+_transport:  !wiseagents.transport.StompWiseAgentTransport
+    _host: localhost
+    _port: 61616
+    _agent_name: Agent1
 ---
 !wiseagents.WiseAgent
 _description: This is another test agent
@@ -30,4 +34,7 @@ _llm: !OpenaiAPIWiseAgentLLM
 _name: Agent2
 _vector_db: !PGVectorLangChainWiseAgentVectorDB
   _connection_string: postgresql+psycopg://langchain:langchain@localhost:6024/langchain
-
+_transport:  !wiseagents.transport.StompWiseAgentTransport
+    _host: localhost
+    _port: 61616
+    _agent_name: Agent1

--- a/tests/wiseagents/test.yaml
+++ b/tests/wiseagents/test.yaml
@@ -14,3 +14,8 @@ _name: Agent1
 _vector_db: !PGVectorLangChainWiseAgentVectorDB
   _connection_string: postgresql+psycopg://langchain:langchain@localhost:6024/langchain
   _embedding_model_name: all-MiniLM-L6-v2
+_transport:  !wiseagents.transport.StompWiseAgentTransport
+    _host: localhost
+    _port: 61616
+    _agent_name: Agent1
+

--- a/tests/wiseagents/test_WiseAgentRegistry.py
+++ b/tests/wiseagents/test_WiseAgentRegistry.py
@@ -34,7 +34,7 @@ def test_register_agents():
         logging.info(f'Agent in the registry={WiseAgentRegistry.get_agent_description(agent.name)}')
         assert agent.description == WiseAgentRegistry.get_agent_description(agent.name)
     finally:    
-        agent.stopAgent()
+        agent.stop_agent()
 
 def test_get_agents():
     try:
@@ -47,7 +47,7 @@ def test_get_agents():
         #stop the agents
     finally:
         for agent in agents:
-            agent.stopAgent()
+            agent.stop_agent()
 
 def test_get_contexts():
     

--- a/tests/wiseagents/test_WiseAgentRegistry.py
+++ b/tests/wiseagents/test_WiseAgentRegistry.py
@@ -9,8 +9,8 @@ from wiseagents.transports.stomp import StompWiseAgentTransport
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
     yield
-    WiseAgentRegistry.clear_agents_descriptions_dict()
-    WiseAgentRegistry.clear_contexts()
+    
+    
 class DummyTransport(WiseAgentTransport):
     
     def send_request(self, message: WiseAgentMessage, dest_agent_name: str):
@@ -24,31 +24,33 @@ class DummyTransport(WiseAgentTransport):
         pass
    
 def test_register_agents():
-    WiseAgentRegistry.clear_agents_descriptions_dict()
-    agent = WiseAgent(name="Agent1", description="This is a test agent", 
+    
+    try:
+        agent = WiseAgent(name="Agent1", description="This is a test agent", 
                       transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="WiseIntelligentAgent")
                                  )
-    assert 1 == WiseAgentRegistry.get_agents_descptions_dict().__len__()
-    logging.info(f'Agent ={agent}')
-    logging.info(f'Agent in the registry={WiseAgentRegistry.get_agent_description(agent.name)}')
-    assert agent.description == WiseAgentRegistry.get_agent_description(agent.name)
-
-def test_remove_agent():
-    agent_name = "Agent1"
-    WiseAgentRegistry.unregister_agent(agent_name)
-    assert None == WiseAgentRegistry.get_agent_description(agent_name)
+        assert 1 == WiseAgentRegistry.fetch_agents_descriptions_dict().__len__()
+        logging.info(f'Agent ={agent}')
+        logging.info(f'Agent in the registry={WiseAgentRegistry.get_agent_description(agent.name)}')
+        assert agent.description == WiseAgentRegistry.get_agent_description(agent.name)
+    finally:    
+        agent.stopAgent()
 
 def test_get_agents():
-    WiseAgentRegistry.clear_agents_descriptions_dict()
-    agents = [WiseAgent(name="Agent1", description="This is a test agent", transport=DummyTransport()), 
-              WiseAgent(name="Agent2", description="This is another test agent", transport=DummyTransport()), 
-              WiseAgent(name="Agent3", description="This is yet another test agent", transport=DummyTransport())]
-    
-    for agent in agents:
-        assert agent.description == WiseAgentRegistry.get_agent_description(agent.name)
+    try:
+        agents = [WiseAgent(name="Agent1", description="This is a test agent", transport=DummyTransport()), 
+                WiseAgent(name="Agent2", description="This is another test agent", transport=DummyTransport()), 
+                WiseAgent(name="Agent3", description="This is yet another test agent", transport=DummyTransport())]
+        
+        for agent in agents:
+            assert agent.description == WiseAgentRegistry.get_agent_description(agent.name)
+        #stop the agents
+    finally:
+        for agent in agents:
+            agent.stopAgent()
 
 def test_get_contexts():
-    WiseAgentRegistry.clear_contexts()
+    
     contexts = [WiseAgentContext(name="Context1"), 
               WiseAgentContext(name="Context2"), 
               WiseAgentContext(name="Context3")]
@@ -57,7 +59,7 @@ def test_get_contexts():
         assert True == WiseAgentRegistry.does_context_exist(context.name)
         
 def test_get_or_create_context():
-    WiseAgentRegistry.clear_contexts()
+    
     context = WiseAgentContext(name="Context1")
     WiseAgentRegistry.get_or_create_context(context.name)
     assert context == WiseAgentRegistry.get_or_create_context(context.name)

--- a/tests/wiseagents/test_WiseAgentRegistry.py
+++ b/tests/wiseagents/test_WiseAgentRegistry.py
@@ -9,7 +9,7 @@ from wiseagents.transports.stomp import StompWiseAgentTransport
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
     yield
-    WiseAgentRegistry.clear_agents()
+    WiseAgentRegistry.clear_agents_descriptions_dict()
     WiseAgentRegistry.clear_contexts()
 class DummyTransport(WiseAgentTransport):
     
@@ -24,28 +24,28 @@ class DummyTransport(WiseAgentTransport):
         pass
    
 def test_register_agents():
-    WiseAgentRegistry.clear_agents()
+    WiseAgentRegistry.clear_agents_descriptions_dict()
     agent = WiseAgent(name="Agent1", description="This is a test agent", 
                       transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="WiseIntelligentAgent")
                                  )
-    assert 1 == WiseAgentRegistry.get_agents().__len__()
+    assert 1 == WiseAgentRegistry.get_agents_descptions_dict().__len__()
     logging.info(f'Agent ={agent}')
-    logging.info(f'Agent in the registry={WiseAgentRegistry.get_agent(agent.name)}')
-    assert agent.description == WiseAgentRegistry.get_agent(agent.name)
+    logging.info(f'Agent in the registry={WiseAgentRegistry.get_agent_description(agent.name)}')
+    assert agent.description == WiseAgentRegistry.get_agent_description(agent.name)
 
 def test_remove_agent():
     agent_name = "Agent1"
-    WiseAgentRegistry.remove_agent(agent_name)
-    assert None == WiseAgentRegistry.get_agent(agent_name)
+    WiseAgentRegistry.unregister_agent(agent_name)
+    assert None == WiseAgentRegistry.get_agent_description(agent_name)
 
 def test_get_agents():
-    WiseAgentRegistry.clear_agents()
+    WiseAgentRegistry.clear_agents_descriptions_dict()
     agents = [WiseAgent(name="Agent1", description="This is a test agent", transport=DummyTransport()), 
               WiseAgent(name="Agent2", description="This is another test agent", transport=DummyTransport()), 
               WiseAgent(name="Agent3", description="This is yet another test agent", transport=DummyTransport())]
     
     for agent in agents:
-        assert agent.description == WiseAgentRegistry.get_agent(agent.name)
+        assert agent.description == WiseAgentRegistry.get_agent_description(agent.name)
 
 def test_get_contexts():
     WiseAgentRegistry.clear_contexts()

--- a/tests/wiseagents/test_wise_agent_message_exchange.py
+++ b/tests/wiseagents/test_wise_agent_message_exchange.py
@@ -11,7 +11,7 @@ from wiseagents.transports import StompWiseAgentTransport
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
     yield
-    WiseAgentRegistry.clear_agents()
+    WiseAgentRegistry.clear_agents_descriptions_dict()
     WiseAgentRegistry.clear_contexts()
 
 class WiseAgentDoingNothing(WiseAgent):
@@ -49,7 +49,7 @@ class WiseAgentDoingNothing(WiseAgent):
 def test_send_message_to_agent_and_get_response():
     os.environ['STOMP_USER'] = 'artemis'
     os.environ['STOMP_PASSWORD'] = 'artemis'
-    WiseAgentRegistry.clear_agents()
+    WiseAgentRegistry.clear_agents_descriptions_dict()
     WiseAgentRegistry.clear_contexts()
     agent1 = WiseAgentDoingNothing('Agent1', 'Agent1')
     agent2 = WiseAgentDoingNothing('Agent2', 'Agent2')

--- a/tests/wiseagents/test_wise_agent_message_exchange.py
+++ b/tests/wiseagents/test_wise_agent_message_exchange.py
@@ -11,8 +11,8 @@ from wiseagents.transports import StompWiseAgentTransport
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
     yield
-    WiseAgentRegistry.clear_agents_descriptions_dict()
-    WiseAgentRegistry.clear_contexts()
+    
+    
 
 class WiseAgentDoingNothing(WiseAgent):
      
@@ -49,8 +49,8 @@ class WiseAgentDoingNothing(WiseAgent):
 def test_send_message_to_agent_and_get_response():
     os.environ['STOMP_USER'] = 'artemis'
     os.environ['STOMP_PASSWORD'] = 'artemis'
-    WiseAgentRegistry.clear_agents_descriptions_dict()
-    WiseAgentRegistry.clear_contexts()
+    
+    
     agent1 = WiseAgentDoingNothing('Agent1', 'Agent1')
     agent2 = WiseAgentDoingNothing('Agent2', 'Agent2')
     
@@ -80,5 +80,10 @@ def test_send_message_to_agent_and_get_response():
     assert WiseAgentRegistry.get_or_create_context('default').participants.__len__() == 2
     assert WiseAgentRegistry.get_or_create_context('default').participants[0].name == 'Agent1'
     assert WiseAgentRegistry.get_or_create_context('default').participants[1].name == 'Agent2'
+
+    #stop all agents
+    agent1.stop()
+    agent2.stop()
+
     
     

--- a/tests/wiseagents/test_yaml_deserializer.py
+++ b/tests/wiseagents/test_yaml_deserializer.py
@@ -10,73 +10,82 @@ from wiseagents import WiseAgent, WiseAgentRegistry
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
     yield
-    WiseAgentRegistry.clear_agents_descriptions_dict()
-    WiseAgentRegistry.clear_contexts()
+    
+    
 
 @pytest.mark.needsllm
 def test_using_deserialized_agent():
-    # Create a WiseAgent object
-    with open(pathlib.Path().resolve() / "tests/wiseagents/test.yaml") as stream:
-        try:
-            deserialized_agent = yaml.load(stream, Loader=yaml.Loader)
-        except yaml.YAMLError as exc:
-            print(exc)
-    # Assert that the serialized agent can be deserialized back to a WiseAgent object
+    try:
+        # Create a WiseAgent object
+        with open(pathlib.Path().resolve() / "tests/wiseagents/test.yaml") as stream:
+            try:
+                deserialized_agent = yaml.load(stream, Loader=yaml.Loader)
+            except yaml.YAMLError as exc:
+                print(exc)
+        # Assert that the serialized agent can be deserialized back to a WiseAgent object
 
-    assert isinstance(deserialized_agent, WiseAgent)
-    assert deserialized_agent.name == "Agent1"
-    assert deserialized_agent.description == "This is a test agent"
-    assert deserialized_agent.llm.system_message == "Answer my greeting saying Hello and my name"
-    assert deserialized_agent.llm.model_name == "Phi-3-mini-4k-instruct-q4.gguf"
-    assert deserialized_agent.llm.remote_address == "http://localhost:8001/v1"
-    logging.debug(deserialized_agent)
-    response = deserialized_agent.llm.process_single_prompt("Hello my name is Stefano")
-    assert response.content.__len__() > 0
-    assert deserialized_agent.graph_db.url == "bolt://localhost:7687"
-    assert not deserialized_agent.graph_db.refresh_graph_schema
-    assert deserialized_agent.graph_db.embedding_model_name == "all-MiniLM-L6-v2"
-    assert deserialized_agent.graph_db.collection_name == "test-cli-vector-db"
-    assert deserialized_agent.graph_db.properties == ["name", "type"]
-    assert deserialized_agent.vector_db.connection_string == "postgresql+psycopg://langchain:langchain@localhost:6024/langchain"
-    assert deserialized_agent.vector_db.embedding_model_name == "all-MiniLM-L6-v2"
+        assert isinstance(deserialized_agent, WiseAgent)
+        assert deserialized_agent.name == "Agent1"
+        assert deserialized_agent.description == "This is a test agent"
+        assert deserialized_agent.llm.system_message == "Answer my greeting saying Hello and my name"
+        assert deserialized_agent.llm.model_name == "Phi-3-mini-4k-instruct-q4.gguf"
+        assert deserialized_agent.llm.remote_address == "http://localhost:8001/v1"
+        logging.debug(deserialized_agent)
+        response = deserialized_agent.llm.process_single_prompt("Hello my name is Stefano")
+        assert response.content.__len__() > 0
+        assert deserialized_agent.graph_db.url == "bolt://localhost:7687"
+        assert not deserialized_agent.graph_db.refresh_graph_schema
+        assert deserialized_agent.graph_db.embedding_model_name == "all-MiniLM-L6-v2"
+        assert deserialized_agent.graph_db.collection_name == "test-cli-vector-db"
+        assert deserialized_agent.graph_db.properties == ["name", "type"]
+        assert deserialized_agent.vector_db.connection_string == "postgresql+psycopg://langchain:langchain@localhost:6024/langchain"
+        assert deserialized_agent.vector_db.embedding_model_name == "all-MiniLM-L6-v2"
+    finally:
+        #stop the agent
+        deserialized_agent.stopAgent()
 
 
 @pytest.mark.skip(reason="does not pass CI/CD")
 def test_using_multiple_deserialized_agents():
-    # Create a WiseAgent object
-    deserialized_agent = []
-    with open(pathlib.Path().resolve() / "tests/wiseagents/test-multiple.yaml") as stream:
-        try:
-            for agent in yaml.load_all(stream, Loader=yaml.Loader):
-                deserialized_agent.append(agent)
-        except yaml.YAMLError as exc:
-            print(exc)
-    # Assert that the serialized agent can be deserialized back to a WiseAgent object
-    logging.debug(deserialized_agent)
+    try:
+        # Create a WiseAgent object
+        deserialized_agent = []
+        with open(pathlib.Path().resolve() / "tests/wiseagents/test-multiple.yaml") as stream:
+            try:
+                for agent in yaml.load_all(stream, Loader=yaml.Loader):
+                    deserialized_agent.append(agent)
+            except yaml.YAMLError as exc:
+                print(exc)
+        # Assert that the serialized agent can be deserialized back to a WiseAgent object
+        logging.debug(deserialized_agent)
 
-    #assert isinstance(deserialized_agent[0], WiseAgent)
-    assert deserialized_agent[0].name == "Agent1"
-    assert deserialized_agent[0].description == "This is a test agent"
-    assert deserialized_agent[0].llm.system_message == "Answer my greeting saying Hello and my name"
-    assert deserialized_agent[0].llm.model_name == "Phi-3-mini-4k-instruct-q4.gguf"
-    assert deserialized_agent[0].llm.remote_address == "http://localhost:8001/v1"
-    response = deserialized_agent[0].llm.process("Hello my name is Stefano")
-    assert response.content.__len__() > 0
-    assert deserialized_agent[0].graph_db.url == "bolt://localhost:7687"
-    assert not deserialized_agent[0].graph_db.refresh_graph_schema
-    assert deserialized_agent[0].graph_db.embedding_model_name == "all-MiniLM-L6-v2"
-    assert deserialized_agent[0].vector_db.connection_string == "postgresql+psycopg://langchain:langchain@localhost:6024/langchain"
-    assert deserialized_agent[0].vector_db.embedding_model_name == "all-MiniLM-L6-v2"
-    logging.debug(deserialized_agent[1])
+        #assert isinstance(deserialized_agent[0], WiseAgent)
+        assert deserialized_agent[0].name == "Agent1"
+        assert deserialized_agent[0].description == "This is a test agent"
+        assert deserialized_agent[0].llm.system_message == "Answer my greeting saying Hello and my name"
+        assert deserialized_agent[0].llm.model_name == "Phi-3-mini-4k-instruct-q4.gguf"
+        assert deserialized_agent[0].llm.remote_address == "http://localhost:8001/v1"
+        response = deserialized_agent[0].llm.process("Hello my name is Stefano")
+        assert response.content.__len__() > 0
+        assert deserialized_agent[0].graph_db.url == "bolt://localhost:7687"
+        assert not deserialized_agent[0].graph_db.refresh_graph_schema
+        assert deserialized_agent[0].graph_db.embedding_model_name == "all-MiniLM-L6-v2"
+        assert deserialized_agent[0].vector_db.connection_string == "postgresql+psycopg://langchain:langchain@localhost:6024/langchain"
+        assert deserialized_agent[0].vector_db.embedding_model_name == "all-MiniLM-L6-v2"
+        logging.debug(deserialized_agent[1])
 
-    assert isinstance(deserialized_agent[1], WiseAgent)
-    assert deserialized_agent[1].name == "Agent2"
-    assert deserialized_agent[1].description == "This is another test agent"
-    assert deserialized_agent[1].llm.system_message == "Answer my greeting saying Hello and my name"
-    assert deserialized_agent[1].llm.model_name == "Phi-3-mini-4k-instruct-q4.gguf"
-    assert deserialized_agent[1].llm.remote_address == "http://localhost:8001/v1"
-    response = deserialized_agent[1].llm.process_single_prompt("Hello my name is Stefano")
-    assert response.content.__len__() > 0
-    assert deserialized_agent[1].graph_db.url == "bolt://localhost:7687"
-    assert not deserialized_agent[1].graph_db.refresh_graph_schema
-    assert deserialized_agent[1].vector_db.connection_string == "postgresql+psycopg://langchain:langchain@localhost:6024/langchain"
+        assert isinstance(deserialized_agent[1], WiseAgent)
+        assert deserialized_agent[1].name == "Agent2"
+        assert deserialized_agent[1].description == "This is another test agent"
+        assert deserialized_agent[1].llm.system_message == "Answer my greeting saying Hello and my name"
+        assert deserialized_agent[1].llm.model_name == "Phi-3-mini-4k-instruct-q4.gguf"
+        assert deserialized_agent[1].llm.remote_address == "http://localhost:8001/v1"
+        response = deserialized_agent[1].llm.process_single_prompt("Hello my name is Stefano")
+        assert response.content.__len__() > 0
+        assert deserialized_agent[1].graph_db.url == "bolt://localhost:7687"
+        assert not deserialized_agent[1].graph_db.refresh_graph_schema
+        assert deserialized_agent[1].vector_db.connection_string == "postgresql+psycopg://langchain:langchain@localhost:6024/langchain"
+    finally:
+        #stop all agents
+        for agent in deserialized_agent:
+            agent.stopAgent()

--- a/tests/wiseagents/test_yaml_deserializer.py
+++ b/tests/wiseagents/test_yaml_deserializer.py
@@ -42,7 +42,7 @@ def test_using_deserialized_agent():
         assert deserialized_agent.vector_db.embedding_model_name == "all-MiniLM-L6-v2"
     finally:
         #stop the agent
-        deserialized_agent.stopAgent()
+        deserialized_agent.stop_agent()
 
 
 @pytest.mark.skip(reason="does not pass CI/CD")

--- a/tests/wiseagents/test_yaml_deserializer.py
+++ b/tests/wiseagents/test_yaml_deserializer.py
@@ -10,7 +10,7 @@ from wiseagents import WiseAgent, WiseAgentRegistry
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
     yield
-    WiseAgentRegistry.clear_agents()
+    WiseAgentRegistry.clear_agents_descriptions_dict()
     WiseAgentRegistry.clear_contexts()
 
 @pytest.mark.needsllm

--- a/tests/wiseagents/test_yaml_serializtion.py
+++ b/tests/wiseagents/test_yaml_serializtion.py
@@ -12,7 +12,7 @@ from wiseagents.vectordb import PGVectorLangChainWiseAgentVectorDB
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
     yield
-    WiseAgentRegistry.clear_agents()
+    WiseAgentRegistry.clear_agents_descriptions_dict()
     WiseAgentRegistry.clear_contexts()
 class DummyTransport(WiseAgentTransport):
     def __init__(self):

--- a/tests/wiseagents/test_yaml_serializtion.py
+++ b/tests/wiseagents/test_yaml_serializtion.py
@@ -12,8 +12,8 @@ from wiseagents.vectordb import PGVectorLangChainWiseAgentVectorDB
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
     yield
-    WiseAgentRegistry.clear_agents_descriptions_dict()
-    WiseAgentRegistry.clear_contexts()
+    
+    
 class DummyTransport(WiseAgentTransport):
     def __init__(self):
         pass
@@ -33,86 +33,98 @@ class DummyTransport(WiseAgentTransport):
 
 
 def test_serialize_wise_agent(monkeypatch):
-    # Create a WiseAgent object
-    agent_llm = OpenaiAPIWiseAgentLLM(system_message="Answer my greeting saying Hello and my name",
-                                            model_name="Phi-3-mini-4k-instruct-q4.gguf")
-    agent_graph_db = Neo4jLangChainWiseAgentGraphDB(url="bolt://localhost:7687", refresh_graph_schema=False,
-                                                    embedding_model_name="all-MiniLM-L6-v2", collection_name="test-cli-vector-db",
-                                                    properties=["name", "type"])
-    agent_vector_db = PGVectorLangChainWiseAgentVectorDB(
-        connection_string="postgresql+psycopg://langchain:langchain@localhost:6024/langchain",
-        embedding_model_name="all-MiniLM-L6-v2")
-    agent = WiseAgent(name="Agent1", description="This is a test agent", transport=DummyTransport(), llm=agent_llm,
-                      graph_db=agent_graph_db, vector_db=agent_vector_db)
+    try:
+        # Create a WiseAgent object
+        agent_llm = OpenaiAPIWiseAgentLLM(system_message="Answer my greeting saying Hello and my name",
+                                                model_name="Phi-3-mini-4k-instruct-q4.gguf")
+        agent_graph_db = Neo4jLangChainWiseAgentGraphDB(url="bolt://localhost:7687", refresh_graph_schema=False,
+                                                        embedding_model_name="all-MiniLM-L6-v2", collection_name="test-cli-vector-db",
+                                                        properties=["name", "type"])
+        agent_vector_db = PGVectorLangChainWiseAgentVectorDB(
+            connection_string="postgresql+psycopg://langchain:langchain@localhost:6024/langchain",
+            embedding_model_name="all-MiniLM-L6-v2")
+        agent = WiseAgent(name="Agent1", description="This is a test agent", transport=DummyTransport(), llm=agent_llm,
+                        graph_db=agent_graph_db, vector_db=agent_vector_db)
 
-    # Serialize the WiseAgent object to YAML
-    serialized_agent = yaml.dump(agent)
+        # Serialize the WiseAgent object to YAML
+        serialized_agent = yaml.dump(agent)
+    finally:
+        agent.stopAgent()
+    try:
+        # Assert that the serialized agent is not empty
+        assert serialized_agent is not None
 
-    # Assert that the serialized agent is not empty
-    assert serialized_agent is not None
+        # Assert that the serialized agent is a string
+        assert isinstance(serialized_agent, str)
+        logging.debug(serialized_agent)
 
-    # Assert that the serialized agent is a string
-    assert isinstance(serialized_agent, str)
-    logging.debug(serialized_agent)
+        # Assert that the serialized agent can be deserialized back to a WiseAgent object
+        deserialized_agent = yaml.load(serialized_agent, Loader=yaml.Loader)
+        assert isinstance(deserialized_agent, WiseAgent)
+        assert deserialized_agent.name == agent.name
+        assert deserialized_agent.description == agent.description
+        assert deserialized_agent.llm.system_message == agent.llm.system_message
+        assert deserialized_agent.llm.model_name == agent.llm.model_name
+        assert deserialized_agent.llm.remote_address == "http://localhost:8001/v1"
+        assert deserialized_agent.graph_db.url == "bolt://localhost:7687"
+        assert deserialized_agent.graph_db.collection_name == "test-cli-vector-db"
+        assert deserialized_agent.graph_db.properties == ["name", "type"]
+        assert not deserialized_agent.graph_db.refresh_graph_schema
+        assert deserialized_agent.graph_db.embedding_model_name == "all-MiniLM-L6-v2"
+        assert deserialized_agent.vector_db.connection_string == "postgresql+psycopg://langchain:langchain@localhost:6024/langchain"
+        assert deserialized_agent.vector_db.embedding_model_name == "all-MiniLM-L6-v2"
+        logging.debug(deserialized_agent)
+    finally:
+        deserialized_agent.stopAgent()
 
-    # Assert that the serialized agent can be deserialized back to a WiseAgent object
-    deserialized_agent = yaml.load(serialized_agent, Loader=yaml.Loader)
-    assert isinstance(deserialized_agent, WiseAgent)
-    assert deserialized_agent.name == agent.name
-    assert deserialized_agent.description == agent.description
-    assert deserialized_agent.llm.system_message == agent.llm.system_message
-    assert deserialized_agent.llm.model_name == agent.llm.model_name
-    assert deserialized_agent.llm.remote_address == "http://localhost:8001/v1"
-    assert deserialized_agent.graph_db.url == "bolt://localhost:7687"
-    assert deserialized_agent.graph_db.collection_name == "test-cli-vector-db"
-    assert deserialized_agent.graph_db.properties == ["name", "type"]
-    assert not deserialized_agent.graph_db.refresh_graph_schema
-    assert deserialized_agent.graph_db.embedding_model_name == "all-MiniLM-L6-v2"
-    assert deserialized_agent.vector_db.connection_string == "postgresql+psycopg://langchain:langchain@localhost:6024/langchain"
-    assert deserialized_agent.vector_db.embedding_model_name == "all-MiniLM-L6-v2"
-    logging.debug(deserialized_agent)
+    
 
 
 @pytest.mark.needsllm
 def test_using_deserialized_agent(monkeypatch):
-    # Create a WiseAgent object
-    agent_llm = OpenaiAPIWiseAgentLLM(system_message="Answer my greeting saying Hello and my name",
-                                            model_name="Phi-3-mini-4k-instruct-q4.gguf")
-    agent_graph_db = Neo4jLangChainWiseAgentGraphDB(url="bolt://localhost:7687", refresh_graph_schema=False,
-                                                    embedding_model_name="all-MiniLM-L6-v2", collection_name="test-cli-vector-db",
-                                                    properties=["name", "type"])
-    agent_vector_db = PGVectorLangChainWiseAgentVectorDB(
-        connection_string="postgresql+psycopg://langchain:langchain@localhost:6024/langchain",
-        embedding_model_name="all-MiniLM-L6-v2")
-    agent = WiseAgent(name="Agent1", description="This is a test agent", transport=DummyTransport(), llm=agent_llm,
-                      graph_db=agent_graph_db,
-                      vector_db=agent_vector_db)
+    try:
+        # Create a WiseAgent object
+        agent_llm = OpenaiAPIWiseAgentLLM(system_message="Answer my greeting saying Hello and my name",
+                                                model_name="Phi-3-mini-4k-instruct-q4.gguf")
+        agent_graph_db = Neo4jLangChainWiseAgentGraphDB(url="bolt://localhost:7687", refresh_graph_schema=False,
+                                                        embedding_model_name="all-MiniLM-L6-v2", collection_name="test-cli-vector-db",
+                                                        properties=["name", "type"])
+        agent_vector_db = PGVectorLangChainWiseAgentVectorDB(
+            connection_string="postgresql+psycopg://langchain:langchain@localhost:6024/langchain",
+            embedding_model_name="all-MiniLM-L6-v2")
+        agent = WiseAgent(name="Agent1", description="This is a test agent", transport=DummyTransport(), llm=agent_llm,
+                        graph_db=agent_graph_db,
+                        vector_db=agent_vector_db)
 
-    # Serialize the WiseAgent object to YAML
-    serialized_agent = yaml.dump(agent)
+        # Serialize the WiseAgent object to YAML
+        serialized_agent = yaml.dump(agent)
+    finally:
+        agent.stopAgent()
+    try:
+        # Assert that the serialized agent is not empty
+        assert serialized_agent is not None
 
-    # Assert that the serialized agent is not empty
-    assert serialized_agent is not None
+        # Assert that the serialized agent is a string
+        assert isinstance(serialized_agent, str)
+        logging.debug(serialized_agent)
 
-    # Assert that the serialized agent is a string
-    assert isinstance(serialized_agent, str)
-    logging.debug(serialized_agent)
-
-    # Assert that the serialized agent can be deserialized back to a WiseAgent object
-    deserialized_agent = yaml.load(serialized_agent, Loader=yaml.Loader)
-    assert isinstance(deserialized_agent, WiseAgent)
-    assert deserialized_agent.name == agent.name
-    assert deserialized_agent.description == agent.description
-    assert deserialized_agent.llm.system_message == agent.llm.system_message
-    assert deserialized_agent.llm.model_name == agent.llm.model_name
-    assert deserialized_agent.llm.remote_address == "http://localhost:8001/v1"
-    assert deserialized_agent.graph_db.collection_name == "test-cli-vector-db"
-    assert deserialized_agent.graph_db.properties == ["name", "type"]
-    assert deserialized_agent.graph_db.url == "bolt://localhost:7687"
-    assert not deserialized_agent.graph_db.refresh_graph_schema
-    assert deserialized_agent.graph_db.embedding_model_name == "all-MiniLM-L6-v2"
-    logging.debug(deserialized_agent)
-    response = deserialized_agent.llm.process_single_prompt("Hello my name is Stefano")
-    assert response.content.__len__() > 0
-    assert deserialized_agent.vector_db.connection_string == "postgresql+psycopg://langchain:langchain@localhost:6024/langchain"
-    assert deserialized_agent.vector_db.embedding_model_name == "all-MiniLM-L6-v2"
+        # Assert that the serialized agent can be deserialized back to a WiseAgent object
+        deserialized_agent = yaml.load(serialized_agent, Loader=yaml.Loader)
+        assert isinstance(deserialized_agent, WiseAgent)
+        assert deserialized_agent.name == agent.name
+        assert deserialized_agent.description == agent.description
+        assert deserialized_agent.llm.system_message == agent.llm.system_message
+        assert deserialized_agent.llm.model_name == agent.llm.model_name
+        assert deserialized_agent.llm.remote_address == "http://localhost:8001/v1"
+        assert deserialized_agent.graph_db.collection_name == "test-cli-vector-db"
+        assert deserialized_agent.graph_db.properties == ["name", "type"]
+        assert deserialized_agent.graph_db.url == "bolt://localhost:7687"
+        assert not deserialized_agent.graph_db.refresh_graph_schema
+        assert deserialized_agent.graph_db.embedding_model_name == "all-MiniLM-L6-v2"
+        logging.debug(deserialized_agent)
+        response = deserialized_agent.llm.process_single_prompt("Hello my name is Stefano")
+        assert response.content.__len__() > 0
+        assert deserialized_agent.vector_db.connection_string == "postgresql+psycopg://langchain:langchain@localhost:6024/langchain"
+        assert deserialized_agent.vector_db.embedding_model_name == "all-MiniLM-L6-v2"
+    finally:
+        deserialized_agent.stopAgent()

--- a/tests/wiseagents/test_yaml_serializtion.py
+++ b/tests/wiseagents/test_yaml_serializtion.py
@@ -49,7 +49,7 @@ def test_serialize_wise_agent(monkeypatch):
         # Serialize the WiseAgent object to YAML
         serialized_agent = yaml.dump(agent)
     finally:
-        agent.stopAgent()
+        agent.stop_agent()
     try:
         # Assert that the serialized agent is not empty
         assert serialized_agent is not None
@@ -75,7 +75,7 @@ def test_serialize_wise_agent(monkeypatch):
         assert deserialized_agent.vector_db.embedding_model_name == "all-MiniLM-L6-v2"
         logging.debug(deserialized_agent)
     finally:
-        deserialized_agent.stopAgent()
+        deserialized_agent.stop_agent()
 
     
 
@@ -99,7 +99,7 @@ def test_using_deserialized_agent(monkeypatch):
         # Serialize the WiseAgent object to YAML
         serialized_agent = yaml.dump(agent)
     finally:
-        agent.stopAgent()
+        agent.stop_agent()
     try:
         # Assert that the serialized agent is not empty
         assert serialized_agent is not None
@@ -127,4 +127,4 @@ def test_using_deserialized_agent(monkeypatch):
         assert deserialized_agent.vector_db.connection_string == "postgresql+psycopg://langchain:langchain@localhost:6024/langchain"
         assert deserialized_agent.vector_db.embedding_model_name == "all-MiniLM-L6-v2"
     finally:
-        deserialized_agent.stopAgent()
+        deserialized_agent.stop_agent()


### PR DESCRIPTION
1. refactoring registry for better methods names. it relates to issue #47
2.  Cli and Yaml serializer/deserializer are still using local llm as it is defined in their yaml. This is fixing only the annotation for tests fixed as part of issue #47. test_tools.py is still using local llm intentionally, because it contains the same tests of test_tools_groq but on local llm: I feel we should keep it as is
3. Avoid to register and start 2 agents with the same name Fixes #276
4. Fix camel case method and function names Fixes #290