### PR TITLE
Update the callback method for processing a request so that it calls a few methods to ensure appropriate handling is performed based on the type of collaboration

### DIFF
--- a/src/wiseagents/__init__.py
+++ b/src/wiseagents/__init__.py
@@ -3,6 +3,7 @@
 # Import any modules or subpackages here
 
 from wiseagents.core import WiseAgent
+from wiseagents.core import WiseAgentCollaborationType
 from wiseagents.core import WiseAgentContext
 from wiseagents.core import WiseAgentRegistry
 from wiseagents.core import WiseAgentTool
@@ -16,4 +17,5 @@ from wiseagents.wise_agent_messaging import WiseAgentTransport
 # Optionally, you can define __all__ to specify the public interface of the package
 # __all__ = ['module1', 'module2', 'subpackage']
 __all__ = ['WiseAgentRegistry', 'WiseAgentContext', 'WiseAgent', 'WiseAgentTool',
-           'WiseAgentMessage', 'WiseAgentMessageType', 'WiseAgentTransport', 'WiseAgentEvent']
+           'WiseAgentMessage', 'WiseAgentMessageType', 'WiseAgentTransport', 'WiseAgentEvent',
+           'WiseAgentCollaborationType']

--- a/src/wiseagents/agents/__init__.py
+++ b/src/wiseagents/agents/__init__.py
@@ -6,11 +6,11 @@
 
 # Optionally, you can define __all__ to specify the public interface of the package
 # __all__ = ['module1', 'module2', 'subpackage']
-from .collaboration_wise_agents import CollaboratorWiseAgent, PhasedCoordinatorWiseAgent, SequentialCoordinatorWiseAgent
+from .collaboration_wise_agents import PhasedCoordinatorWiseAgent, SequentialCoordinatorWiseAgent
 from .rag_wise_agents import CoVeChallengerRAGWiseAgent, GraphRAGWiseAgent, RAGWiseAgent
 from .utility_wise_agents import PassThroughClientAgent, LLMOnlyWiseAgent, LLMWiseAgentWithTools
 from .assistant import AssistantAgent
 
-__all__ = ['CollaboratorWiseAgent', 'PhasedCoordinatorWiseAgent', 'SequentialCoordinatorWiseAgent', 'RAGWiseAgent',
+__all__ = ['PhasedCoordinatorWiseAgent', 'SequentialCoordinatorWiseAgent', 'RAGWiseAgent',
            'GraphRAGWiseAgent', 'CoVeChallengerRAGWiseAgent', 'PassThroughClientAgent', 'LLMOnlyWiseAgent',
            'LLMWiseAgentWithTools', 'AssistantAgent']

--- a/src/wiseagents/agents/collaboration_wise_agents.py
+++ b/src/wiseagents/agents/collaboration_wise_agents.py
@@ -2,7 +2,7 @@ import logging
 import uuid
 from typing import Callable, List, Optional
 
-from wiseagents import WiseAgent, WiseAgentMessage, WiseAgentMessageType, WiseAgentRegistry, WiseAgentTransport
+from wiseagents import WiseAgent, WiseAgentCollaborationType, WiseAgentMessage, WiseAgentMessageType, WiseAgentRegistry, WiseAgentTransport
 from wiseagents.llm import WiseAgentLLM
 
 CONFIDENCE_SCORE_THRESHOLD = 85
@@ -34,7 +34,7 @@ class SequentialCoordinatorWiseAgent(WiseAgent):
         """Return a string representation of the agent."""
         return f"{self.__class__.__name__}(name={self.name}, description={self.description}, agents={self.agents})"
 
-    def process_request(self, request):
+    def handle_request(self, request):
         """
         Process a request message by passing it to the first agent in the sequence.
 
@@ -47,6 +47,7 @@ class SequentialCoordinatorWiseAgent(WiseAgent):
         chat_id = str(uuid.uuid4())
 
         ctx = WiseAgentRegistry.get_or_create_context(request.context_name)
+        ctx.set_collaboration_type(chat_id, WiseAgentCollaborationType.SEQUENTIAL)
         ctx.set_agents_sequence(chat_id, self._agents)
         ctx.set_route_response_to(chat_id, request.sender)
         self.send_request(WiseAgentMessage(message=request.message, sender=self.name, context_name=request.context_name,
@@ -182,7 +183,7 @@ class PhasedCoordinatorWiseAgent(WiseAgent):
         """Get the confidence score threshold."""
         return self._confidence_score_threshold
 
-    def process_request(self, request):
+    def handle_request(self, request):
         """
         Process a request message by kicking off the collaboration in phases.
 
@@ -195,6 +196,7 @@ class PhasedCoordinatorWiseAgent(WiseAgent):
         chat_id = str(uuid.uuid4())
 
         ctx = WiseAgentRegistry.get_or_create_context(request.context_name)
+        ctx.set_collaboration_type(chat_id, WiseAgentCollaborationType.PHASED)
         ctx.set_route_response_to(chat_id, request.sender)
 
         # Determine the agents required to answer the query
@@ -352,103 +354,3 @@ class PhasedCoordinatorWiseAgent(WiseAgent):
         """
         self._response_delivery = response_delivery
 
-
-class CollaboratorWiseAgent(WiseAgent):
-    """
-    This agent implementation is meant to be used in conjunction with a CoordinatorWiseAgent.
-    A collaborator agent will receive a request from a coordinator agent and will process the
-    request, adding its response to the shared context. The collaborator agent will then send
-    the coordinator agent a message to let the coordinator know that it has finished executing
-    its work.
-    """
-    yaml_tag = u'!wiseagents.agents.CollaboratorWiseAgent'
-
-    def __new__(cls, *args, **kwargs):
-        """Create a new instance of the class, setting default values for the instance variables."""
-        obj = super().__new__(cls)
-        obj._system_message = None
-        return obj
-
-    def __init__(self, name: str, description: str, llm: WiseAgentLLM, transport: WiseAgentTransport,
-                 system_message: Optional[str] = None):
-        """
-        Initialize the agent.
-
-        Args:
-            name (str): the name of the agent
-            description (str): a description of the agent
-            llm (WiseAgentLLM): the LLM agent to use for processing requests
-            transport (WiseAgentTransport): the transport to use for communication
-            system_message (Optional[str]): the optional system message to be used by the collaborator when processing
-            chat completions using its LLM
-        """
-        self._name = name
-        self._description = description
-        self._transport = transport
-        self._llm = llm
-        self._system_message = system_message
-        super().__init__(name=name, description=description, transport=self.transport, llm=llm, system_message=system_message)
-
-    def __repr__(self):
-        """Return a string representation of the agent."""
-        return (f"{self.__class__.__name__}(name={self.name}, description={self.description}, llm={self.llm},"
-                f"transport={self.transport}, system_message={self.system_message})")
-
-    def process_event(self, event):
-        """Do nothing"""
-        return True
-
-    def process_error(self, error):
-        """Log the error and return True."""
-        logging.error(error)
-        return True
-
-    def process_request(self, request: WiseAgentMessage):
-        """
-        Process a request message by passing it to the LLM and then send a response back to the sender
-        to let them know the request has been processed.
-
-        Args:
-            request (WiseAgentMessage): the request message to process
-        """
-        ctx = WiseAgentRegistry.get_or_create_context(request.context_name)
-        chat_id = request.chat_id
-        if chat_id is not None and ctx.llm_chat_completion != {}:
-            # Get the chat messages so far
-            messages = ctx.llm_chat_completion[chat_id]
-        else:
-            messages = []
-
-        messages.append({"role": "system", "content": self.system_message or self.llm.system_message})
-        messages.append({"role": "user", "content": request.message})
-        llm_response = self.llm.process_chat_completion(messages, [])
-
-        # Add this agent's response to the shared context
-        ctx.append_chat_completion(chat_uuid=chat_id, messages=llm_response.choices[0].message)
-
-        # Let the sender know that this agent has finished processing the request
-        self.send_response(
-            WiseAgentMessage(message=llm_response.choices[0].message.content, message_type=WiseAgentMessageType.ACK, sender=self.name, context_name=request.context_name,
-                             chat_id=request.chat_id), request.sender)
-        return True
-
-    def process_response(self, response: WiseAgentMessage):
-        """Do nothing"""
-        return True
-
-    def get_recipient_agent_name(self, message):
-        """
-        Return the name of the agent to send the message to.
-
-        Args:
-            message (WiseAgentMessage): the message to process
-        """
-        return self.name
-
-    def stop(self):
-        pass
-
-    @property
-    def name(self) -> str:
-        """Get the name of the agent."""
-        return self._name

--- a/src/wiseagents/agents/collaboration_wise_agents.py
+++ b/src/wiseagents/agents/collaboration_wise_agents.py
@@ -60,17 +60,8 @@ class SequentialCoordinatorWiseAgent(WiseAgent):
         Args:
             response (WiseAgentMessage): the response message to process
         """
-        ctx = WiseAgentRegistry.get_or_create_context(response.context_name)
-        chat_id = response.chat_id
-        next_agent = ctx.get_next_agent_in_sequence(chat_id, response.sender)
-        if next_agent is None:
-            logging.debug(f"Sequential coordinator sending response from " + response.sender + " to " + ctx.get_route_response_to(chat_id))
-            self.send_response(WiseAgentMessage(message=response.message, sender=self.name, context_name=response.context_name),
-                               ctx.get_route_response_to(chat_id))
-        else:
-            logging.debug(f"Sequential coordinator sending response from " + response.sender + " to " + next_agent)
-            self.send_request(WiseAgentMessage(message=response.message, sender=self.name, context_name=response.context_name,
-                                               chat_id=chat_id), next_agent)
+        if response.message:
+            raise ValueError(f"Unexpected response message: {response.message}")
         return True
 
     def process_event(self, event):

--- a/src/wiseagents/agents/rag_wise_agents.py
+++ b/src/wiseagents/agents/rag_wise_agents.py
@@ -2,10 +2,11 @@ import json
 import logging
 from typing import Any, Dict, List, Optional
 
-from wiseagents import WiseAgent, WiseAgentMessage, WiseAgentTransport
+from wiseagents import WiseAgent, WiseAgentCollaborationType, WiseAgentMessage, WiseAgentTransport
 from wiseagents.graphdb import WiseAgentGraphDB
 from wiseagents.llm import WiseAgentLLM
 from wiseagents.vectordb import Document, WiseAgentVectorDB
+from openai.types.chat import ChatCompletionMessageParam
 
 """The default number of documents to retrieve during retrieval augmented generation (RAG)."""
 DEFAULT_NUM_DOCUMENTS = 4
@@ -33,11 +34,13 @@ class RAGWiseAgent(WiseAgent):
         obj._collection_name = DEFAULT_COLLECTION_NAME
         obj._k = DEFAULT_NUM_DOCUMENTS
         obj._include_sources = DEFAULT_INCLUDE_SOURCES
+        obj._system_message = None
         return obj
 
     def __init__(self, name: str, description: str, llm: WiseAgentLLM, vector_db: WiseAgentVectorDB,
                  transport: WiseAgentTransport, collection_name: Optional[str] = DEFAULT_COLLECTION_NAME,
-                 k: Optional[int] = DEFAULT_NUM_DOCUMENTS, include_sources: Optional[bool] = DEFAULT_INCLUDE_SOURCES):
+                 k: Optional[int] = DEFAULT_NUM_DOCUMENTS, include_sources: Optional[bool] = DEFAULT_INCLUDE_SOURCES,
+                 system_message: Optional[str] = None):
         """
         Initialize the agent.
 
@@ -61,13 +64,13 @@ class RAGWiseAgent(WiseAgent):
         self._k = k
         self._include_sources = include_sources
         super().__init__(name=name, description=description, transport=self.transport, llm=llm,
-                         vector_db=vector_db, collection_name=collection_name)
+                         vector_db=vector_db, collection_name=collection_name, system_message=system_message)
 
     def __repr__(self):
         """Return a string representation of the agent."""
         return (f"{self.__class__.__name__}(name={self.name}, description={self.description}, llm={self.llm},"
                 f"vector_db={self.vector_db}, collection_name={self.collection_name}, transport={self.transport},"
-                f"k={self.k}, include_sources={self.include_sources})")
+                f"k={self.k}, include_sources={self.include_sources}), system_message={self.system_message})")
 
     def process_event(self, event):
         """Do nothing"""
@@ -78,18 +81,25 @@ class RAGWiseAgent(WiseAgent):
         logging.error(error)
         return True
 
-    def process_request(self, request: WiseAgentMessage):
+    def process_request(self, request: WiseAgentMessage, conversation_history: List[ChatCompletionMessageParam]) -> Optional[str]:
         """
-        Process a request message using retrieval augmented generation (RAG) and sending the response back to the client.
+        Process a request message using retrieval augmented generation (RAG).
 
         Args:
             request (WiseAgentMessage): the request message to process
+            conversation_history (List[ChatCompletionMessageParam]): The conversation history that
+            can be used while processing the request. If this agent isn't involved in a type of
+            collaboration that makes use of the conversation history, this will be an empty list.
+
+        Returns:
+            Optional[str]: the response to the request message as a string or None if there is
+            no string response yet
         """
         retrieved_documents = self.vector_db.query([request.message], self.collection_name, self.k)
         llm_response_with_sources = _create_and_process_rag_prompt(retrieved_documents[0], request.message, self.llm,
-                                                                   self.include_sources)
-        self.send_response(WiseAgentMessage(llm_response_with_sources, self.name), request.sender)
-        return True
+                                                                   self.include_sources, conversation_history,
+                                                                   self.system_message)
+        return llm_response_with_sources
 
     def process_response(self, response: WiseAgentMessage):
         """Do nothing"""
@@ -132,13 +142,14 @@ class GraphRAGWiseAgent(WiseAgent):
         obj._retrieval_query = ""
         obj._params = None
         obj._metadata_filter = None
+        obj._system_message = None
         return obj
 
     def __init__(self, name: str, description: str, llm: WiseAgentLLM, graph_db: WiseAgentGraphDB,
                  transport: WiseAgentTransport, k: Optional[int] = DEFAULT_NUM_DOCUMENTS,
                  include_sources: Optional[bool] = DEFAULT_INCLUDE_SOURCES,
                  retrieval_query: Optional[str] = "", params: Optional[Dict[str, Any]] = None,
-                 metadata_filter: Optional[Dict[str, Any]] = None):
+                 metadata_filter: Optional[Dict[str, Any]] = None, system_message: Optional[str] = None):
         """
         Initialize the agent.
 
@@ -155,6 +166,8 @@ class GraphRAGWiseAgent(WiseAgent):
             retrieved from a similarity search
             params (Optional[Dict[str, Any]]): the optional parameters for the query
             metadata_filter (Optional[Dict[str, Any]]): the optional metadata filter to use with similarity search
+            system_message (Optional[str]): the optional system message to be used by the collaborator when processing
+            chat completions using its LLM
         """
         self._name = name
         self._description = description
@@ -166,14 +179,14 @@ class GraphRAGWiseAgent(WiseAgent):
         self._params = params
         self._metadata_filter = metadata_filter
         super().__init__(name=name, description=description, transport=self.transport, llm=llm,
-                         graph_db=graph_db)
+                         graph_db=graph_db, system_message=system_message)
 
     def __repr__(self):
         """Return a string representation of the agent."""
         return (f"{self.__class__.__name__}(name={self.name}, description={self.description}, llm={self.llm},"
                 f"graph_db={self.graph_db}, transport={self.transport}, k={self.k},"
                 f"include_sources={self.include_sources}), retrieval_query={self.retrieval_query},"
-                f"params={self.params}, metadata_filter={self.metadata_filter})")
+                f"params={self.params}, metadata_filter={self.metadata_filter}, system_message={self.system_message})")
 
     def process_event(self, event):
         """Do nothing"""
@@ -184,20 +197,27 @@ class GraphRAGWiseAgent(WiseAgent):
         logging.error(error)
         return True
 
-    def process_request(self, request: WiseAgentMessage):
+    def process_request(self, request: WiseAgentMessage, conversation_history: List[ChatCompletionMessageParam]) -> Optional[str]:
         """
         Process a request message by passing it to the RAG agent and sending the response back to the client.
 
         Args:
             request (WiseAgentMessage): the request message to process
+            conversation_history (List[ChatCompletionMessageParam]): The conversation history that
+            can be used while processing the request. If this agent isn't involved in a type of
+            collaboration that makes use of the conversation history, this will be an empty list.
+
+        Returns:
+            Optional[str]: the response to the request message as a string or None if there is
+            no string response yet
         """
         retrieved_documents = self.graph_db.query_with_embeddings(query=request.message, k=self.k,
                                                                   retrieval_query=self.retrieval_query,
                                                                   params=self.params,
                                                                   metadata_filter=self.metadata_filter)
-        llm_response_with_sources = _create_and_process_rag_prompt(retrieved_documents, request.message, self.llm, self.include_sources)
-        self.send_response(WiseAgentMessage(llm_response_with_sources, self.name), request.sender)
-        return True
+        llm_response_with_sources = _create_and_process_rag_prompt(retrieved_documents, request.message, self.llm, self.include_sources,
+                                                                   conversation_history, self.system_message)
+        return llm_response_with_sources
 
     def process_response(self, response: WiseAgentMessage):
         """Do nothing"""
@@ -260,12 +280,14 @@ class CoVeChallengerRAGWiseAgent(WiseAgent):
         obj._num_verification_questions = 4
         obj._include_sources = DEFAULT_INCLUDE_SOURCES
         obj._num_verification_questions = DEFAULT_NUM_VERIFICATION_QUESTIONS
+        obj._system_message = None
         return obj
 
     def __init__(self, name: str, description: str, llm: WiseAgentLLM, vector_db: WiseAgentVectorDB,
                  transport: WiseAgentTransport, collection_name: Optional[str] = DEFAULT_COLLECTION_NAME,
                  k: Optional[int] = DEFAULT_NUM_DOCUMENTS,
-                 num_verification_questions: Optional[int] = DEFAULT_NUM_VERIFICATION_QUESTIONS):
+                 num_verification_questions: Optional[int] = DEFAULT_NUM_VERIFICATION_QUESTIONS,
+                 system_message: Optional[str] = None):
         """
         Initialize the agent.
 
@@ -278,6 +300,8 @@ class CoVeChallengerRAGWiseAgent(WiseAgent):
             collection_name Optional(str): the name of the collection to use in the vector database, defaults to wise-agents-collection
             k Optional(int): the number of documents to retrieve from the vector database, defaults to 4
             num_verification_questions Optional(int): the number of verification questions to generate, defaults to 4
+            system_message (Optional[str]): the optional system message to be used by the collaborator when processing
+            chat completions using its LLM
         """
         self._name = name
         self._description = description
@@ -288,13 +312,14 @@ class CoVeChallengerRAGWiseAgent(WiseAgent):
         self._num_verification_questions = num_verification_questions
         llm_agent = llm
         super().__init__(name=name, description=description, transport=self.transport, llm=llm_agent,
-                         vector_db=vector_db, collection_name=collection_name)
+                         vector_db=vector_db, collection_name=collection_name, system_message=system_message)
 
     def __repr__(self):
         """Return a string representation of the agent."""
         return (f"{self.__class__.__name__}(name={self.name}, description={self.description}, llm={self.llm},"
                 f"vector_db={self.vector_db}, collection_name={self.collection_name}, k={self.k},"
-                f"num_verification_questions={self._num_verification_questions}, transport={self.transport})")
+                f"num_verification_questions={self._num_verification_questions}, transport={self.transport},"
+                f"system_message={self.system_message})")
 
     def process_event(self, event):
         """Do nothing"""
@@ -305,17 +330,22 @@ class CoVeChallengerRAGWiseAgent(WiseAgent):
         logging.error(error)
         return True
 
-    def process_request(self, request: WiseAgentMessage):
+    def process_request(self, request: WiseAgentMessage, conversation_history: List[ChatCompletionMessageParam]) -> Optional[str]:
         """
         Process a message containing a question and a baseline response to the question
         by challenging the baseline response to generate a revised response to the original question.
 
         Args:
             request (WiseAgentMessage): the request message to process
+            conversation_history (List[ChatCompletionMessageParam]): The conversation history that
+            can be used while processing the request. If this agent isn't involved in a type of
+            collaboration that makes use of the conversation history, this will be an empty list.
+
+        Returns:
+            str: the response to the request message as a string
         """
-        llm_response = self._create_and_process_chain_of_verification_prompts(request.message)
-        self.send_response(WiseAgentMessage(llm_response, self.name), request.sender)
-        return True
+        llm_response = self._create_and_process_chain_of_verification_prompts(request.message, conversation_history)
+        return llm_response
 
     def process_response(self, response: WiseAgentMessage):
         """Do nothing"""
@@ -344,32 +374,39 @@ class CoVeChallengerRAGWiseAgent(WiseAgent):
         """Get the number of verification questions to generate."""
         return self._num_verification_questions
 
-    def _create_and_process_chain_of_verification_prompts(self, message: str) -> str:
+    def _create_and_process_chain_of_verification_prompts(self, message: str, conversation_history: List[ChatCompletionMessageParam]) -> str:
         """
         Create prompts to challenge the baseline response to a question to try to generate a revised response
         to the original question.
 
         Args:
             message (str): the message containing the question and baseline response
+            conversation_history (List[ChatCompletionMessageParam]): The conversation history that
+            can be used while processing the request. If this agent isn't involved in a type of
+            collaboration that makes use of the conversation history, this will be an empty list.
         """
 
         """Plan verifications"""
         prompt = (f"Given the following question and baseline response, generate a list of {self.num_verification_questions} "
                   f" verification questions that could help determine if there are any mistakes in the baseline response:\n{message}\n"
                   f"Your response should contain only the list of questions, one per line.\n")
-        llm_response = self.llm.process_single_prompt(prompt)
+        conversation_history.append({"role": "system", "content": self.system_message or self.llm.system_message})
+        conversation_history.append({"role": "user", "content": prompt})
+        llm_response = self.llm.process_chat_completion(conversation_history, [])
 
         """Execute verifications"""
-        verification_questions = llm_response.content.splitlines()
+        verification_questions = llm_response.choices[0].message.content.splitlines()
         verification_responses = ""
         for question in verification_questions:
             retrieved_documents = self.vector_db.query([question], self.collection_name, self.k)
             context = "\n".join([document.content for document in retrieved_documents[0]])
             prompt = (f"Answer the question based only on the following context:\n{context}\n"
                       f"Question: {question}\n")
-            llm_response = self.llm.process_single_prompt(prompt)
+            conversation_history.append({"role": "system", "content": self.system_message or self.llm.system_message})
+            conversation_history.append({"role": "user", "content": prompt})
+            llm_response = self.llm.process_chat_completion(conversation_history, [])
             verification_responses = (verification_responses + "Verification Question: " + question + "\n"
-                                      + "Verification Result: " + llm_response.content + "\n")
+                                      + "Verification Result: " + llm_response.choices[0].message.content + "\n")
 
         """Generate the final revised response"""
         complete_info = message + "\n" + verification_responses
@@ -378,23 +415,33 @@ class CoVeChallengerRAGWiseAgent(WiseAgent):
                   f"Your response must contain only the revised response to the question in the JSON format shown below:\n"
                   f"{{'revised': 'Your revised response to the question.'}}\n")
 
-        llm_response = self.llm.process_single_prompt(prompt)
-        return llm_response.content
+        conversation_history.append({"role": "system", "content": self.system_message or self.llm.system_message})
+        conversation_history.append({"role": "user", "content": prompt})
+        llm_response = self.llm.process_chat_completion(conversation_history, [])
+        return llm_response.choices[0].message.content
 
 
 def _create_and_process_rag_prompt(retrieved_documents: List[Document], question: str, llm: WiseAgentLLM,
-                                   include_sources: bool) -> str:
-    """Create a RAG prompt and process it with the LLM agent.
+                                   include_sources: bool, conversation_history: List[ChatCompletionMessageParam],
+                                   system_message: str) -> str:
+    """
+    Create a RAG prompt and process it with the LLM agent.
 
     Args:
         retrieved_documents (List[Document]): the list of retrieved documents
         question (str): the question to ask
         llm (WiseAgentLLM): the LLM agent to use for processing the prompt
+        conversation_history (List[ChatCompletionMessageParam]): The conversation history that
+            can be used while processing the request. If this agent isn't involved in a type of
+            collaboration that makes use of the conversation history, this will be an empty list.
+        system_message (str): the optional system message to use
     """
     context = "\n".join([document.content for document in retrieved_documents])
     prompt = (f"Answer the question based only on the following context:\n{context}\n"
               f"Question: {question}\n")
-    llm_response = llm.process_single_prompt(prompt)
+    conversation_history.append({"role": "system", "content": system_message or llm.system_message})
+    conversation_history.append({"role": "user", "content": prompt})
+    llm_response = llm.process_chat_completion(conversation_history, [])
 
     if include_sources:
         source_documents = ""
@@ -402,4 +449,4 @@ def _create_and_process_rag_prompt(retrieved_documents: List[Document], question
             source_documents += f"Source Document:\n    Content: {document.content}\n    Metadata: {json.dumps(document.metadata)}\n\n"
         return f"{llm_response.content}\n\nSource Documents:\n{source_documents}"
     else:
-        return llm_response.content
+        return llm_response.choices[0].message.content

--- a/src/wiseagents/core.py
+++ b/src/wiseagents/core.py
@@ -3,7 +3,9 @@ import json
 import logging
 import os
 import pickle
+
 from abc import abstractmethod
+from enum import Enum, auto
 from typing import Any, Callable, Dict, Iterable, List, Optional
 
 import yaml
@@ -11,207 +13,16 @@ from openai.types.chat import ChatCompletionToolParam, ChatCompletionMessagePara
 
 import redis
 from wiseagents.graphdb import WiseAgentGraphDB
-from wiseagents.llm import WiseAgentLLM
+from wiseagents.llm import OpenaiAPIWiseAgentLLM, WiseAgentLLM
 from wiseagents.vectordb import WiseAgentVectorDB
-from wiseagents.wise_agent_messaging import WiseAgentMessage, WiseAgentTransport, WiseAgentEvent
+from wiseagents.wise_agent_messaging import WiseAgentMessage, WiseAgentMessageType, WiseAgentTransport, WiseAgentEvent
 
 
-class WiseAgent(yaml.YAMLObject):
-    ''' A WiseAgent is an abstract class that represents an agent that can send and receive messages to and from other agents.
-    '''
-    yaml_tag = u'!wiseagents.WiseAgent'
+class WiseAgentCollaborationType(Enum):
+    SEQUENTIAL = auto()
+    PHASED = auto()
+    INDEPENDENT = auto()
 
-    def __new__(cls, *args, **kwargs):
-        '''Create a new instance of the class, setting default values for the instance variables.'''
-        obj = super().__new__(cls)
-        obj._llm = None
-        obj._vector_db = None
-        obj._graph_db = None
-        obj._collection_name = "wise-agent-collection"
-        obj._system_message = None
-        return obj
-
-    def __init__(self, name: str, description: str, transport: WiseAgentTransport, llm: Optional[WiseAgentLLM] = None,
-                 vector_db: Optional[WiseAgentVectorDB] = None, collection_name: Optional[str] = "wise-agent-collection",
-                 graph_db: Optional[WiseAgentGraphDB] = None, system_message: Optional[str] = None):
-        ''' 
-        Initialize the agent with the given name, description, transport, LLM, vector DB, collection name, and graph DB.
-        
-
-        Args:
-            name (str): the name of the agent
-            description (str): a description of what the agent does
-            transport (WiseAgentTransport): the transport to use for sending and receiving messages
-            llm Optional(WiseAgentLLM): the LLM associated with the agent
-            vector_db Optional(WiseAgentVectorDB): the vector DB associated with the agent
-            collection_name Optional(str) = "wise-agent-collection": the vector DB collection name associated with the agent
-            graph_db Optional (WiseAgentGraphDB): the graph DB associated with the agent
-            system_message Optional(str): an optional system message that can be used by the agent when processing chat
-            completions using its LLM
-        '''
-        self._name = name
-        self._description = description
-        self._llm = llm
-        self._vector_db = vector_db
-        self._collection_name = collection_name
-        self._graph_db = graph_db
-        self._transport = transport
-        self._system_message = system_message
-        self.start_agent()
-        
-    def start_agent(self):
-        ''' Start the agent by setting the call backs and starting the transport.'''
-        self.transport.set_call_backs(self.process_request, self.process_event, self.process_error, self.process_response)
-        self.transport.start()
-        WiseAgentRegistry.register_agent(self.name, self.description) 
-    
-    def stop_agent(self):
-        ''' Stop the agent by stopping the transport and removing the agent from the registry.'''
-        self.transport.stop()
-        WiseAgentRegistry.unregister_agent(self.name)
-    
-    def __repr__(self):
-        '''Return a string representation of the agent.'''
-        return (f"{self.__class__.__name__}(name={self.name}, description={self.description}, llm={self.llm},"
-                f"vector_db={self.vector_db}, collection_name={self._collection_name}, graph_db={self.graph_db},"
-                f"system_message={self.system_message})")
-    
-    def __eq__(self, value: object) -> bool:
-        return isinstance(value, WiseAgent) and self.__repr__() == value.__repr__()
-
-    @property
-    def name(self) -> str:
-        """Get the name of the agent."""
-        return self._name
-
-    @property
-    def description(self) -> str:
-        """Get a description of what the agent does."""
-        return self._description
-
-    @property
-    def llm(self) -> Optional[WiseAgentLLM]:
-        """Get the LLM associated with the agent."""
-        return self._llm
-
-    @property
-    def vector_db(self) -> Optional[WiseAgentVectorDB]:
-        """Get the vector DB associated with the agent."""
-        return self._vector_db
-
-    @property
-    def collection_name(self) -> str:
-        """Get the vector DB collection name associated with the agent."""
-        return self._collection_name
-
-    @property
-    def graph_db(self) -> Optional[WiseAgentGraphDB]:
-        """Get the graph DB associated with the agent."""
-        return self._graph_db
-    
-    @property
-    def transport(self) -> WiseAgentTransport:
-        """Get the transport associated with the agent."""
-        return self._transport
-
-    @property
-    def system_message(self) -> Optional[str]:
-        """Get the system message associated with the agent."""
-        return self._system_message
-
-    def send_request(self, message: WiseAgentMessage, dest_agent_name: str):
-        '''Send a request message to the destination agent with the given name.
-
-        Args:
-            message (WiseAgentMessage): the message to send
-            dest_agent_name (str): the name of the destination agent'''
-        message.sender = self.name
-        context = WiseAgentRegistry.get_or_create_context(message.context_name)
-        context.add_participant(self.name)
-        self.transport.send_request(message, dest_agent_name)
-        context.trace(message)
-    
-    def send_response(self, message: WiseAgentMessage, dest_agent_name):
-        '''Send a response message to the destination agent with the given name.
-
-        Args:
-            message (WiseAgentMessage): the message to send
-            dest_agent_name (str): the name of the destination agent'''
-        message.sender = self.name
-        context = WiseAgentRegistry.get_or_create_context(message.context_name)
-        context.add_participant(self.name)
-        self.transport.send_response(message, dest_agent_name)
-        context.trace(message)  
-    
-    @abstractmethod
-    def process_request(self, message: WiseAgentMessage) -> bool:
-        """
-        Callback method to process the given request for this agent.
-
-
-        Args:
-            message (WiseAgentMessage): the message to be processed
-
-        Returns:
-            True if the message was processed successfully, False otherwise
-        """
-        ...
-
-    @abstractmethod
-    def process_response(self, message: WiseAgentMessage) -> bool:
-        """
-        Callback method to process the response received from another agent which processed a request from this agent.
-
-
-        Args:
-            message (WiseAgentMessage): the message to be processed
-
-        Returns:
-            True if the message was processed successfully, False otherwise
-        """
-        ...
-
-    @abstractmethod
-    def process_event(self, event: WiseAgentEvent) -> bool:
-        """
-        Callback method to process the given event.
-
-
-        Args:
-            event (WiseAgentEvent): the event to be processed
-
-        Returns:
-           True if the event was processed successfully, False otherwise
-        """
-        ...
-        
-    @abstractmethod
-    def process_error(self, error: Exception) -> bool:
-        """
-        Callback method to process the given error.
-
-
-        Args:
-            error (Exception): the error to be processed
-
-        Returns:
-            True if the error was processed successfully, False otherwise
-        """
-        ...
-
-    @abstractmethod
-    def get_recipient_agent_name(self, message: WiseAgentMessage) -> str:
-        """
-        Get the name of the agent to send the given message to.
-
-
-        Args:
-             message (WiseAgentMessage): the message to be sent
-
-        Returns:
-            str: the name of the agent to send the given message to
-        """
-        ...
 
 class WiseAgentTool(yaml.YAMLObject):
     ''' A WiseAgentTool is an abstract class that represents a tool that can be used by an agent to perform a specific task.'''
@@ -293,7 +104,6 @@ class WiseAgentTool(yaml.YAMLObject):
         return self.call_back(**kwargs)
 
 
-
 class WiseAgentContext():
     
     ''' A WiseAgentContext is a class that represents a context in which agents can communicate with each other.
@@ -333,11 +143,15 @@ class WiseAgentContext():
     # Maps a chat uuid to a list containing the queries attempted for each iteration executed by
     # the phased coordinator
     _queries : Dict[str, List[str]] = {}
-    
+
+    # Maps a chat uuid to the collaboration type
+    _collaboration_type: Dict[str, WiseAgentCollaborationType] = {}
+
     _redis_db : redis.Redis = None
     _use_redis : bool = False
     _config : Dict[str, Any] = {}
-    
+
+
     def __init__(self, name: str, config : Optional[Dict[str,Any]] = {"use_redis": False}):
         ''' Initialize the context with the given name.
 
@@ -959,6 +773,339 @@ class WiseAgentContext():
             return self._queries.get(chat_uuid)
         else:
             return []
+
+    @property
+    def collaboration_type(self) -> Dict[str, WiseAgentCollaborationType]:
+        """Get the collaboration type for chat uuids for this context."""
+        if (self._use_redis == True):
+            return_dict: Dict[str, WiseAgentCollaborationType] = {}
+            redis_dict = self._redis_db.hgetall("collaboration_type")
+            for key in redis_dict:
+                return_dict[key.decode('utf-8')] = pickle.loads(redis_dict[key])
+            return return_dict
+        else:
+            return self._collaboration_type
+
+    def get_collaboration_type(self, chat_uuid: str) -> WiseAgentCollaborationType:
+        """
+        Get the collaboration type for the given chat uuid for this context.
+        Args:
+            chat_uuid (Optional[str]): the chat uuid, may be None
+        Returns:
+            WiseAgentCollaborationType: the collaboration type
+        """
+        if (self._use_redis == True):
+            if chat_uuid is not None:
+                collaboration_type = self._redis_db.hget("collaboration_type", key=chat_uuid)
+                if (collaboration_type is not None):
+                    return pickle.loads(collaboration_type)
+            else:
+                return WiseAgentCollaborationType.INDEPENDENT
+        else:
+            if chat_uuid in self._collaboration_type:
+                return self._collaboration_type.get(chat_uuid)
+            else:
+                return WiseAgentCollaborationType.INDEPENDENT
+
+    def set_collaboration_type(self, chat_uuid: str, collaboration_type: WiseAgentCollaborationType):
+        """
+        Set the collaboration type for the given chat uuid for this context.
+
+        Args:
+            chat_uuid (str): the chat uuid
+            collaboration_type (WiseAgentCollaborationType): the collaboration type
+        """
+        if (self._use_redis == True):
+            self._redis_db.hset("collaboration_type", key=chat_uuid, value=pickle.dumps(collaboration_type))
+        else:
+            self._collaboration_type[chat_uuid] = collaboration_type
+
+
+class WiseAgent(yaml.YAMLObject):
+    ''' A WiseAgent is an abstract class that represents an agent that can send and receive messages to and from other agents.
+    '''
+    yaml_tag = u'!wiseagents.WiseAgent'
+
+    def __new__(cls, *args, **kwargs):
+        '''Create a new instance of the class, setting default values for the instance variables.'''
+        obj = super().__new__(cls)
+        obj._llm = None
+        obj._vector_db = None
+        obj._graph_db = None
+        obj._collection_name = "wise-agent-collection"
+        obj._system_message = None
+        return obj
+
+    def __init__(self, name: str, description: str, transport: WiseAgentTransport, llm: Optional[WiseAgentLLM] = None,
+                 vector_db: Optional[WiseAgentVectorDB] = None,
+                 collection_name: Optional[str] = "wise-agent-collection",
+                 graph_db: Optional[WiseAgentGraphDB] = None, system_message: Optional[str] = None):
+        ''' 
+        Initialize the agent with the given name, description, transport, LLM, vector DB, collection name, and graph DB.
+
+
+        Args:
+            name (str): the name of the agent
+            description (str): a description of what the agent does
+            transport (WiseAgentTransport): the transport to use for sending and receiving messages
+            llm Optional(WiseAgentLLM): the LLM associated with the agent
+            vector_db Optional(WiseAgentVectorDB): the vector DB associated with the agent
+            collection_name Optional(str) = "wise-agent-collection": the vector DB collection name associated with the agent
+            graph_db Optional (WiseAgentGraphDB): the graph DB associated with the agent
+            system_message Optional(str): an optional system message that can be used by the agent when processing chat
+            completions using its LLM
+        '''
+        self._name = name
+        self._description = description
+        self._llm = llm
+        self._vector_db = vector_db
+        self._collection_name = collection_name
+        self._graph_db = graph_db
+        self._transport = transport
+        self._system_message = system_message
+        self.start_agent()
+
+    def start_agent(self):
+        ''' Start the agent by setting the call backs and starting the transport.'''
+        self.transport.set_call_backs(self.handle_request, self.process_event, self.process_error,
+                                      self.process_response)
+        self.transport.start()
+        WiseAgentRegistry.register_agent(self.name, self.description)
+
+    def stop_agent(self):
+        ''' Stop the agent by stopping the transport and removing the agent from the registry.'''
+        self.transport.stop()
+        WiseAgentRegistry.unregister_agent(self.name)
+
+    def __repr__(self):
+        '''Return a string representation of the agent.'''
+        return (f"{self.__class__.__name__}(name={self.name}, description={self.description}, llm={self.llm},"
+                f"vector_db={self.vector_db}, collection_name={self._collection_name}, graph_db={self.graph_db},"
+                f"system_message={self.system_message})")
+
+    def __eq__(self, value: object) -> bool:
+        return isinstance(value, WiseAgent) and self.__repr__() == value.__repr__()
+
+    @property
+    def name(self) -> str:
+        """Get the name of the agent."""
+        return self._name
+
+    @property
+    def description(self) -> str:
+        """Get a description of what the agent does."""
+        return self._description
+
+    @property
+    def llm(self) -> Optional[WiseAgentLLM]:
+        """Get the LLM associated with the agent."""
+        return self._llm
+
+    @property
+    def vector_db(self) -> Optional[WiseAgentVectorDB]:
+        """Get the vector DB associated with the agent."""
+        return self._vector_db
+
+    @property
+    def collection_name(self) -> str:
+        """Get the vector DB collection name associated with the agent."""
+        return self._collection_name
+
+    @property
+    def graph_db(self) -> Optional[WiseAgentGraphDB]:
+        """Get the graph DB associated with the agent."""
+        return self._graph_db
+
+    @property
+    def transport(self) -> WiseAgentTransport:
+        """Get the transport associated with the agent."""
+        return self._transport
+
+    @property
+    def system_message(self) -> Optional[str]:
+        """Get the system message associated with the agent."""
+        return self._system_message
+
+    def send_request(self, message: WiseAgentMessage, dest_agent_name: str):
+        '''Send a request message to the destination agent with the given name.
+
+        Args:
+            message (WiseAgentMessage): the message to send
+            dest_agent_name (str): the name of the destination agent'''
+        message.sender = self.name
+        context = WiseAgentRegistry.get_or_create_context(message.context_name)
+        context.add_participant(self.name)
+        self.transport.send_request(message, dest_agent_name)
+        context.trace(message)
+
+    def send_response(self, message: WiseAgentMessage, dest_agent_name):
+        '''Send a response message to the destination agent with the given name.
+
+        Args:
+            message (WiseAgentMessage): the message to send
+            dest_agent_name (str): the name of the destination agent'''
+        message.sender = self.name
+        context = WiseAgentRegistry.get_or_create_context(message.context_name)
+        context.add_participant(self.name)
+        self.transport.send_response(message, dest_agent_name)
+        context.trace(message)
+
+    def handle_request(self, request: WiseAgentMessage) -> bool:
+        """
+        Callback method to handle the given request for this agent. This method optionally retrieves
+        conversation history from the shared context depending on the type of collaboration the agent
+        is involved in (i.e., sequential, phased, or independent) and passes this to the process_request
+        method. Finally, it handles the response from the process_request method, ensuring the shared
+        context is updated if necessary, and determines which agent to the send the response to, both
+        depending on the type of collaboration the agent is involved in.
+        Args:
+            request (WiseAgentMessage): the request message to be processed
+        Returns:
+            True if the message was processed successfully, False otherwise
+        """
+        context = WiseAgentRegistry.get_or_create_context(request.context_name)
+        collaboration_type = context.get_collaboration_type(request.chat_id)
+        conversation_history = self.get_conversation_history_if_needed(context, request.chat_id, collaboration_type)
+        response_str = self.process_request(request, conversation_history)
+        return self.handle_response(response_str, request, context, collaboration_type)
+
+    def get_conversation_history_if_needed(self, context: WiseAgentContext,
+                                           chat_id: Optional[str], collaboration_type: str) -> List[
+        ChatCompletionMessageParam]:
+        """
+        Get the conversation history for the given chat id from the given context, depending on the
+        type of collaboration the agent is involved in (i.e., sequential, phased, independent).
+
+        Args:
+            context (WiseAgentContext): the shared context
+            chat_id (Optional[str]): the chat id, may be None
+            collaboration_type (str): the type of collaboration this agent is involved in
+
+        Returns:
+            List[ChatCompletionMessageParam]: the conversation history for the given chat id if the agent
+            is involved in a collaboration type that makes use of the conversation history and an empty list
+            otherwise
+        """
+        if chat_id:
+            if collaboration_type == WiseAgentCollaborationType.PHASED:
+                # this agent is involved in phased collaboration, so it needs the conversation history
+                return context.llm_chat_completion.get(chat_id)
+        # for sequential collaboration and independent agents, the shared history is not needed
+        return []
+
+    @abstractmethod
+    def process_request(self, request: WiseAgentMessage,
+                        conversation_history: List[ChatCompletionMessageParam]) -> Optional[str]:
+        """
+        Process the given request message to generate a response string.
+
+        Args:
+            request (WiseAgentMessage): the request message to be processed
+            conversation_history (List[ChatCompletionMessageParam]): The conversation history that
+            can be used while processing the request. If this agent isn't involved in a type of
+            collaboration that makes use of the conversation history, this will be an empty list.
+
+        Returns:
+            Optional[str]: the response to the request message as a string or None if there is
+            no string response yet
+        """
+        ...
+
+    def handle_response(self, response_str: str, request: WiseAgentMessage,
+                        context: WiseAgentContext, collaboration_type: str) -> bool:
+        """
+        Handles the given string response, ensuring the shared context is updated if necessary
+        and determines which agent to the send the response to, both depending on the type of
+        collaboration the agent is involved in (i.e., sequential, phased, or independent).
+
+        Args:
+            response_str (str): the string response to be handled
+            context (WiseAgentContext): the shared context
+            chat_id (Optional[str]): the chat id, may be None
+            collaboration_type (str): the type of collaboration this agent is involved in
+
+        Returns:
+            True if the message was processed successfully, False otherwise
+        """
+        if response_str:
+            if collaboration_type == WiseAgentCollaborationType.PHASED:
+                # add this agent's response to the shared context
+                context.append_chat_completion(chat_uuid=request.chat_id,
+                                               messages={"role": "assistant", "content": response_str})
+
+                # let the sender know that this agent has finished processing the request
+                self.send_response(
+                    WiseAgentMessage(message="", message_type=WiseAgentMessageType.ACK, sender=self.name,
+                                     context_name=context.name,
+                                     chat_id=request.chat_id), request.sender)
+            elif collaboration_type == WiseAgentCollaborationType.SEQUENTIAL:
+                # TODO: Could tweak this to just send the response to the next agent in the sequence or
+                # if there are no agents remaining, just send it back to the coordinator
+                # See https://github.com/wise-agents/wise-agents/issues/238
+                self.send_response(WiseAgentMessage(message=response_str, sender=self.name,
+                                                    context_name=context.name, chat_id=request.chat_id),
+                                   request.sender)
+            else:
+                self.send_response(WiseAgentMessage(message=response_str, sender=self.name,
+                                                    context_name=context.name, chat_id=request.chat_id),
+                                   request.sender)
+        return True
+
+    @abstractmethod
+    def process_response(self, message: WiseAgentMessage) -> bool:
+        """
+        Callback method to process the response received from another agent which processed a request from this agent.
+
+
+        Args:
+            message (WiseAgentMessage): the message to be processed
+
+        Returns:
+            True if the message was processed successfully, False otherwise
+        """
+        ...
+
+    @abstractmethod
+    def process_event(self, event: WiseAgentEvent) -> bool:
+        """
+        Callback method to process the given event.
+
+
+        Args:
+            event (WiseAgentEvent): the event to be processed
+
+        Returns:
+           True if the event was processed successfully, False otherwise
+        """
+        ...
+
+    @abstractmethod
+    def process_error(self, error: Exception) -> bool:
+        """
+        Callback method to process the given error.
+
+
+        Args:
+            error (Exception): the error to be processed
+
+        Returns:
+            True if the error was processed successfully, False otherwise
+        """
+        ...
+
+    @abstractmethod
+    def get_recipient_agent_name(self, message: WiseAgentMessage) -> str:
+        """
+        Get the name of the agent to send the given message to.
+
+
+        Args:
+             message (WiseAgentMessage): the message to be sent
+
+        Returns:
+            str: the name of the agent to send the given message to
+        """
+        ...
 
 
 class WiseAgentRegistry:

--- a/tests/wiseagents/agents/test_phased_coordinator.py
+++ b/tests/wiseagents/agents/test_phased_coordinator.py
@@ -5,12 +5,13 @@ import threading
 import pytest
 
 from wiseagents import WiseAgentMessage, WiseAgentRegistry
-from wiseagents.agents import CollaboratorWiseAgent, PassThroughClientAgent, PhasedCoordinatorWiseAgent
+from wiseagents.agents import LLMOnlyWiseAgent, PassThroughClientAgent, \
+    PhasedCoordinatorWiseAgent
 from wiseagents.llm import OpenaiAPIWiseAgentLLM
 from wiseagents.transports import StompWiseAgentTransport
 
 cond = threading.Condition()
-
+assertError : AssertionError = None
 
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
@@ -21,8 +22,12 @@ def run_after_all_tests():
 def final_response_delivered(message: WiseAgentMessage):
     with cond:
         response = message.message
-        assert response
-        print(f"C Response delivered: {response}")
+        try:
+            assert response
+            print(f"C Response delivered: {response}")
+        except AssertionError:
+            logging.info(f"assertion failed")
+            assertError = AssertionError
         cond.notify()
 
 
@@ -32,6 +37,7 @@ def test_phased_coordinator():
     """
     try:
         groq_api_key = os.getenv("GROQ_API_KEY")
+        global assertError
 
         llm = OpenaiAPIWiseAgentLLM(system_message="You are a helpful assistant.",
                                     model_name="llama-3.1-70b-versatile",
@@ -39,49 +45,52 @@ def test_phased_coordinator():
                                     api_key=groq_api_key)
 
         agent1 = PhasedCoordinatorWiseAgent(name="Coordinator", description="This is a coordinator agent", llm=llm,
-                                    transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="Coordinator"),
-                                    phases=["Information Gathering", "Verification of Information", "Analysis"],
-                                    system_message="You will be coordinating a group of agents to solve a problem.",
-                                    max_iterations=2)
+                                            transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="Coordinator"),
+                                            phases=["Information Gathering", "Verification of Information", "Analysis"],
+                                            system_message="You will be coordinating a group of agents to solve a problem.",
+                                            max_iterations=2)
 
-        agent2 = CollaboratorWiseAgent(name="Agent2", description="This agent provides information about error messages using Source1", llm=llm,
-                                    transport=StompWiseAgentTransport(host='localhost', port=61616,
-                                                                        agent_name="Agent2"),
-                                    system_message="You are a helpful assistant that will provide information about the given error message")
+        agent2 = LLMOnlyWiseAgent(name="Agent2", description="This agent provides information about error messages using Source1", llm=llm,
+                                  transport=StompWiseAgentTransport(host='localhost', port=61616,
+                                                                    agent_name="Agent2"),
+                                  system_message="You are a helpful assistant that will provide information about the given error message")
 
-        agent3 = CollaboratorWiseAgent(name="Agent3", description="This agent provides information about error messages using Source2",
-                                    llm=llm,
-                                    transport=StompWiseAgentTransport(host='localhost', port=61616,
-                                                                        agent_name="Agent3"),
-                                    system_message="You are a helpful assistant that will provide information about the given error message")
+        agent3 = LLMOnlyWiseAgent(name="Agent3", description="This agent provides information about error messages using Source2",
+                                  llm=llm,
+                                  transport=StompWiseAgentTransport(host='localhost', port=61616,
+                                                                    agent_name="Agent3"),
+                                  system_message="You are a helpful assistant that will provide information about the given error message")
 
-        agent4 = CollaboratorWiseAgent(name="Agent4",
-                                    description="This agent describes the underlying cause of a problem given information about the problem. This agent" +
-                                                " should be called after getting information about the problem using Agent2 or Agent3.",
-                                    llm=llm,
-                                    transport=StompWiseAgentTransport(host='localhost', port=61616,
-                                                                        agent_name="Agent4"),
-                                    system_message="You are a helpful assistant that will determine the underlying cause of a problem given information about the problem")
+        agent4 = LLMOnlyWiseAgent(name="Agent4",
+                                  description="This agent describes the underlying cause of a problem given information about the problem. This agent" +
+                                              " should be called after getting information about the problem using Agent2 or Agent3.",
+                                  llm=llm,
+                                  transport=StompWiseAgentTransport(host='localhost', port=61616,
+                                                                    agent_name="Agent4"),
+                                  system_message="You are a helpful assistant that will determine the underlying cause of a problem given information about the problem")
 
-        agent5 = CollaboratorWiseAgent(name="Agent5",
-                                    description="This agent is used to verify if the information provided by other agents is accurate. This " +
-                                                "agent should be called after getting information about a problem using Agent2 or Agent3. This agent " +
-                                                "should be called before calling Agent4.",
-                                    llm=llm,
-                                    transport=StompWiseAgentTransport(host='localhost', port=61616,
-                                                                        agent_name="Agent5"),
-                                    system_message="You will determine if the information provided by other agents is accurate.")
+        agent5 = LLMOnlyWiseAgent(name="Agent5",
+                                  description="This agent is used to verify if the information provided by other agents is accurate. This " +
+                                              "agent should be called after getting information about a problem using Agent2 or Agent3. This agent " +
+                                              "should be called before calling Agent4.",
+                                  llm=llm,
+                                  transport=StompWiseAgentTransport(host='localhost', port=61616,
+                                                                    agent_name="Agent5"),
+                                  system_message="You will determine if the information provided by other agents is accurate.")
 
         with cond:
             client_agent1 = PassThroughClientAgent(name="PassThroughClientAgent1", description="This is a test agent",
-                                                transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="PassThroughClientAgent1")
-                                                )
+                                                   transport=StompWiseAgentTransport(host='localhost', port=61616, agent_name="PassThroughClientAgent1")
+                                                   )
             client_agent1.set_response_delivery(final_response_delivered)
             client_agent1.send_request(WiseAgentMessage("How do I prevent the following exception from occurring:"
-                                                        "Exception Details: java.lang.NullPointerException at com.example.ExampleApp.processData(ExampleApp.java:47)", 
+                                                        "Exception Details: java.lang.NullPointerException at com.example.ExampleApp.processData(ExampleApp.java:47)",
                                                         "PassThroughClientAgent1"),
-                                    "Coordinator")
+                                       "Coordinator")
             cond.wait()
+            if assertError is not None:
+                logging.info(f"assertion failed")
+                raise assertError
 
             logging.debug(f"registered agents= {WiseAgentRegistry.fetch_agents_descriptions_dict()}")
             for message in WiseAgentRegistry.get_or_create_context('default').message_trace:

--- a/tests/wiseagents/agents/test_tools.py
+++ b/tests/wiseagents/agents/test_tools.py
@@ -61,7 +61,7 @@ class WiseAgentWeather(WiseAgent):
     def process_error(self, error):
         logging.error(error)
         return True
-    def process_request(self, request: WiseAgentMessage):
+    def handle_request(self, request: WiseAgentMessage):
         self.request_received = request
         logging.info(f"Received request: {request.message}")
         function_args = json.loads(request.message)

--- a/tests/wiseagents/agents/test_tools_groq.py
+++ b/tests/wiseagents/agents/test_tools_groq.py
@@ -62,7 +62,7 @@ class WiseAgentWeather(WiseAgent):
     def process_error(self, error):
         logging.error(error)
         return True
-    def process_request(self, request: WiseAgentMessage):
+    def handle_request(self, request: WiseAgentMessage):
         self.request_received = request
         logging.info(f"Received request: {request.message}")
         function_args = json.loads(request.message)

--- a/tests/wiseagents/test_wise_agent_message_exchange.py
+++ b/tests/wiseagents/test_wise_agent_message_exchange.py
@@ -31,7 +31,7 @@ class WiseAgentDoingNothing(WiseAgent):
     def process_error(self, error):
         logging.error(error)
         return True
-    def process_request(self, request: WiseAgentMessage):
+    def handle_request(self, request: WiseAgentMessage):
         self.request_received = request
         self.send_response(WiseAgentMessage('I am doing nothing', self.name), request.sender )
         return True


### PR DESCRIPTION
Fixes:

* https://github.com/wise-agents/wise-agents/issues/281
* https://github.com/wise-agents/wise-agents/issues/238 

With these changes, it's now possible to update the handling for sequential collaboration so that the response from one agent is sent directly to the next agent until no agents remain at which point the final response is routed appropriately using route_response_to. This makes it possible to reduce the number of messages exchanged since each agent no longer needs to go back to the sequential coordinator first. I've added this fix for https://github.com/wise-agents/wise-agents/issues/238 in this PR as well.