### PR TITLE
FIxing issue #257 : Adding a contributing_lnk.md including the content from CONTRIBUTING.md

### DIFF
--- a/docs/contributing_lnk.md
+++ b/docs/contributing_lnk.md
@@ -1,0 +1,3 @@
+{%
+    include-markdown "../CONTRIBUTING.md"
+%}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ nav:
   - API Reference: reference/
   - About:
     - Community: community.md
-    - Contributing: contributing.md
+    - Contributing: contributing_lnk.md
     - License: license.md
     - Security: security.md
 plugins: 


### PR DESCRIPTION
With a second page including the same content we can have two different navigation contexts.
