### PR TITLE
#251 Don't set env vars in tests.

### DIFF
--- a/tests/wiseagents/__init__.py
+++ b/tests/wiseagents/__init__.py
@@ -1,8 +1,11 @@
 # This is the __init__.py file for the wiseagents package
 
 # Import any modules or subpackages here
+from .testing_utils import assert_env_var_set, assert_env_vars_set, assert_standard_variables_set
 
 # Define any necessary initialization code here
 
 # Optionally, you can define __all__ to specify the public interface of the package
 # __all__ = ['module1', 'module2', 'subpackage']
+
+__all__ = ['assert_env_var_set', 'assert_env_vars_set', 'assert_standard_variables_set']

--- a/tests/wiseagents/agents/test_graph_rag_challenger.py
+++ b/tests/wiseagents/agents/test_graph_rag_challenger.py
@@ -11,6 +11,7 @@ from wiseagents.agents.rag_wise_agents import CoVeChallengerGraphRAGWiseAgent
 from wiseagents.graphdb import Entity, GraphDocument, Neo4jLangChainWiseAgentGraphDB, Relationship, Source
 from wiseagents.llm import OpenaiAPIWiseAgentLLM
 from wiseagents.transports import StompWiseAgentTransport
+from tests.wiseagents import assert_standard_variables_set
 
 cond = threading.Condition()
 assertError : AssertionError = None
@@ -19,11 +20,10 @@ assertError : AssertionError = None
 collection_name = "test-vector-db"
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
+
+    assert_standard_variables_set()
+
     # Ensure that nothing exists the graph DB
-    original_neo4j_username = os.environ.get("NEO4J_USERNAME")
-    os.environ["NEO4J_USERNAME"] = "neo4j"
-    original_neo4j_password = os.environ.get("NEO4J_PASSWORD")
-    os.environ["NEO4J_PASSWORD"] = "neo4jpassword"
     graph_db = Neo4jLangChainWiseAgentGraphDB(properties=["name", "type"], collection_name=collection_name,
                                               url="bolt://localhost:7687", refresh_graph_schema=False)
     graph_db.query("MATCH (n)-[r]-() DELETE r")
@@ -53,33 +53,6 @@ def run_after_all_tests():
     graph_db.query("MATCH (n) DELETE n")
     graph_db.delete_vector_db()
     graph_db.close()
-
-    # Clean up environment variables
-    if original_neo4j_username is None:
-        del os.environ["NEO4J_USERNAME"]
-    else:
-        os.environ["NEO4J_USERNAME"] = original_neo4j_username
-    if original_neo4j_password is None:
-        del os.environ["NEO4J_PASSWORD"]
-    else:
-        os.environ["NEO4J_PASSWORD"] = original_neo4j_password
-
-    
-    
-    
-
-
-def set_env_variable(env_variable: str, value: str) -> str:
-    original_value = os.environ.get(env_variable)
-    os.environ[env_variable] = value
-    return original_value
-
-
-def reset_env_variable(env_variable: str, original_value: str):
-    if original_value is None:
-        del os.environ[env_variable]
-    else:
-        os.environ[env_variable] = original_value
 
 
 def get_connection_string():

--- a/tests/wiseagents/agents/test_phased_coordinator.py
+++ b/tests/wiseagents/agents/test_phased_coordinator.py
@@ -9,12 +9,14 @@ from wiseagents.agents import LLMOnlyWiseAgent, PassThroughClientAgent, \
     PhasedCoordinatorWiseAgent
 from wiseagents.llm import OpenaiAPIWiseAgentLLM
 from wiseagents.transports import StompWiseAgentTransport
+from tests.wiseagents import assert_standard_variables_set
 
 cond = threading.Condition()
 assertError : AssertionError = None
 
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
+    assert_standard_variables_set()
     yield
     
     
@@ -37,6 +39,7 @@ def test_phased_coordinator():
     """
     try:
         groq_api_key = os.getenv("GROQ_API_KEY")
+
         global assertError
 
         llm = OpenaiAPIWiseAgentLLM(system_message="You are a helpful assistant.",

--- a/tests/wiseagents/agents/test_rag_challenger.py
+++ b/tests/wiseagents/agents/test_rag_challenger.py
@@ -9,6 +9,7 @@ from wiseagents.agents import CoVeChallengerRAGWiseAgent, PassThroughClientAgent
 from wiseagents.llm import OpenaiAPIWiseAgentLLM
 from wiseagents.transports import StompWiseAgentTransport
 from wiseagents.vectordb import Document, PGVectorLangChainWiseAgentVectorDB
+from tests.wiseagents import assert_standard_variables_set
 
 cond = threading.Condition()
 assertError : AssertionError = None
@@ -16,12 +17,7 @@ assertError : AssertionError = None
 
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
-    original_postgres_user = set_env_variable("POSTGRES_USER", "postgres")
-    original_postgres_password = set_env_variable("POSTGRES_PASSWORD", "postgres")
-    original_postgres_db = set_env_variable("POSTGRES_DB", "postgres")
-    original_stomp_user = set_env_variable("STOMP_USER", "artemis")
-    original_stomp_password = set_env_variable("STOMP_PASSWORD", "artemis")
-
+    assert_standard_variables_set()
     # Vector DB set up
     pg_vector_db = PGVectorLangChainWiseAgentVectorDB(get_connection_string())
     pg_vector_db.delete_collection("wise-agents-collection")
@@ -39,29 +35,6 @@ def run_after_all_tests():
 
     # Vector DB clean up
     pg_vector_db.delete_collection("wise-agents-collection")
-
-    # Clean up environment variables
-    reset_env_variable("POSTGRES_USER", original_postgres_user)
-    reset_env_variable("POSTGRES_PASSWORD", original_postgres_password)
-    reset_env_variable("POSTGRES_DB", original_postgres_db)
-    reset_env_variable("STOMP_USER", original_stomp_user)
-    reset_env_variable("STOMP_PASSWORD", original_stomp_password)
-    
-    
-    
-
-
-def set_env_variable(env_variable: str, value: str) -> str:
-    original_value = os.environ.get(env_variable)
-    os.environ[env_variable] = value
-    return original_value
-
-
-def reset_env_variable(env_variable: str, original_value: str):
-    if original_value is None:
-        del os.environ[env_variable]
-    else:
-        os.environ[env_variable] = original_value
 
 
 def get_connection_string():

--- a/tests/wiseagents/agents/test_sequential_coordinator.py
+++ b/tests/wiseagents/agents/test_sequential_coordinator.py
@@ -12,6 +12,7 @@ from wiseagents.agents import LLMOnlyWiseAgent, PassThroughClientAgent, Sequenti
     SequentialMemoryCoordinatorWiseAgent
 from wiseagents.llm import OpenaiAPIWiseAgentLLM, WiseAgentLLM
 from wiseagents.transports import StompWiseAgentTransport
+from tests.wiseagents import assert_standard_variables_set
 
 cond1 = threading.Condition()
 cond2 = threading.Condition()
@@ -20,6 +21,7 @@ assertError : AssertionError = None
 
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
+    assert_standard_variables_set()
     yield
 
 

--- a/tests/wiseagents/agents/test_tools.py
+++ b/tests/wiseagents/agents/test_tools.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 import threading
 
 import pytest
@@ -9,10 +8,12 @@ from wiseagents import WiseAgent, WiseAgentMessage, WiseAgentMetaData, WiseAgent
 from wiseagents.agents import LLMWiseAgentWithTools, PassThroughClientAgent
 from wiseagents.llm import OpenaiAPIWiseAgentLLM
 from wiseagents.transports.stomp import StompWiseAgentTransport
+from tests.wiseagents import assert_standard_variables_set
 
 
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
+    assert_standard_variables_set()
     yield
     
     

--- a/tests/wiseagents/agents/test_tools_fakeLLM.py
+++ b/tests/wiseagents/agents/test_tools_fakeLLM.py
@@ -10,10 +10,12 @@ from wiseagents import WiseAgentMessage, WiseAgentMetaData, WiseAgentRegistry, W
 from wiseagents.agents import LLMWiseAgentWithTools, PassThroughClientAgent
 from wiseagents.llm import WiseAgentRemoteLLM
 from wiseagents.transports.stomp import StompWiseAgentTransport
+from tests.wiseagents import assert_standard_variables_set
 
 
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
+    assert_standard_variables_set()
     yield
     
     

--- a/tests/wiseagents/agents/test_tools_groq.py
+++ b/tests/wiseagents/agents/test_tools_groq.py
@@ -9,10 +9,12 @@ from wiseagents import WiseAgent, WiseAgentMessage, WiseAgentMetaData, WiseAgent
 from wiseagents.agents import LLMWiseAgentWithTools, PassThroughClientAgent
 from wiseagents.llm import OpenaiAPIWiseAgentLLM
 from wiseagents.transports.stomp import StompWiseAgentTransport
+from tests.wiseagents import assert_standard_variables_set
 
 
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
+    assert_standard_variables_set()
     yield
     
     

--- a/tests/wiseagents/cli/test_WiseAgentCli.py
+++ b/tests/wiseagents/cli/test_WiseAgentCli.py
@@ -7,17 +7,11 @@ from wiseagents import WiseAgentRegistry
 from wiseagents.cli.wise_agent_cli import main
 from wiseagents.graphdb import Entity, GraphDocument, Neo4jLangChainWiseAgentGraphDB, Relationship, Source
 from wiseagents.vectordb import Document, PGVectorLangChainWiseAgentVectorDB
-
+from tests.wiseagents import assert_standard_variables_set
 
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
-    original_postgres_user = set_env_variable("POSTGRES_USER", "postgres")
-    original_postgres_password = set_env_variable("POSTGRES_PASSWORD", "postgres")
-    original_postgres_db = set_env_variable("POSTGRES_DB", "postgres")
-    original_stomp_user = set_env_variable("STOMP_USER", "artemis")
-    original_stomp_password = set_env_variable("STOMP_PASSWORD", "artemis")
-    original_neo4j_username = set_env_variable("NEO4J_USERNAME", "neo4j")
-    original_neo4j_password = set_env_variable("NEO4J_PASSWORD", "neo4jpassword")
+    assert_standard_variables_set()
 
     # Vector DB set up
     pg_vector_db = PGVectorLangChainWiseAgentVectorDB(get_connection_string())
@@ -60,43 +54,9 @@ def run_after_all_tests():
     graph_db.delete_vector_db()
     graph_db.close()
 
-    # Clean up environment variables
-    reset_env_variable("POSTGRES_USER", original_postgres_user)
-    reset_env_variable("POSTGRES_PASSWORD", original_postgres_password)
-    reset_env_variable("POSTGRES_DB", original_postgres_db)
-    reset_env_variable("STOMP_USER", original_stomp_user)
-    reset_env_variable("STOMP_PASSWORD", original_stomp_password)
-    reset_env_variable("NEO4J_USERNAME", original_neo4j_username)
-    reset_env_variable("NEO4J_PASSWORD", original_neo4j_password)
-    
-    
-    
-
-def set_env_variable(env_variable: str, value: str) -> str:
-    original_value = os.environ.get(env_variable)
-    os.environ[env_variable] = value
-    return original_value
-
-
-def reset_env_variable(env_variable: str, original_value: str):
-    if original_value is None:
-        del os.environ[env_variable]
-    else:
-        os.environ[env_variable] = original_value
-
 
 def get_connection_string():
     return f"postgresql+psycopg://{os.environ['POSTGRES_USER']}:{os.environ['POSTGRES_PASSWORD']}@localhost:6024/{os.environ['POSTGRES_DB']}"
-
-
-def set_env(monkeypatch):
-    """
-        This test requires a running pgvector instance. The required
-        vector database can be started using the run_vectordb.sh script.
-    """
-    monkeypatch.setenv("POSTGRES_USER", "postgres")
-    monkeypatch.setenv("POSTGRES_PASSWORD", "postgres")
-    monkeypatch.setenv("POSTGRES_DB", "postgres")
 
 
 @pytest.mark.needsllm

--- a/tests/wiseagents/graphdb/test_Neo4jLangChainWiseAgentGraphDB.py
+++ b/tests/wiseagents/graphdb/test_Neo4jLangChainWiseAgentGraphDB.py
@@ -1,17 +1,13 @@
-import os
-
 import pytest
 
 from wiseagents.graphdb import Entity, GraphDocument, Neo4jLangChainWiseAgentGraphDB, Relationship, Source
+from tests.wiseagents import assert_standard_variables_set
 
 collection_name = "test-vector-db"
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
+    assert_standard_variables_set()
     # Ensure that nothing exists the graph DB
-    original_neo4j_username = os.environ.get("NEO4J_USERNAME")
-    os.environ["NEO4J_USERNAME"] = "neo4j"
-    original_neo4j_password = os.environ.get("NEO4J_PASSWORD")
-    os.environ["NEO4J_PASSWORD"] = "neo4jpassword"
     graph_db = Neo4jLangChainWiseAgentGraphDB(properties=["name", "type"], collection_name=collection_name,
                                               url="bolt://localhost:7687", refresh_graph_schema=False)
     graph_db.query("MATCH (n)-[r]-() DELETE r")
@@ -27,30 +23,9 @@ def run_after_all_tests():
     graph_db.delete_vector_db()
     graph_db.close()
 
-    # Clean up environment variables
-    if original_neo4j_username is None:
-        del os.environ["NEO4J_USERNAME"]
-    else:
-        os.environ["NEO4J_USERNAME"] = original_neo4j_username
-    if original_neo4j_password is None:
-        del os.environ["NEO4J_PASSWORD"]
-    else:
-        os.environ["NEO4J_PASSWORD"] = original_neo4j_password
 
 
-def set_env(monkeypatch):
-    """
-        This test requires a running Neo4j instance on bolt://localhost:7687. The required
-        graph database can be started using the run_graphdb.sh script.
-    """
-    monkeypatch.setenv("NEO4J_USERNAME", "neo4j")
-    assert os.environ.get("NEO4J_USERNAME") == "neo4j"
-    monkeypatch.setenv("NEO4J_PASSWORD", "neo4jpassword")
-    assert os.environ.get("NEO4J_PASSWORD") == "neo4jpassword"
-
-
-def test_insert_graph_documents_and_query(monkeypatch):
-    set_env(monkeypatch)
+def test_insert_graph_documents_and_query():
     graph_db = Neo4jLangChainWiseAgentGraphDB(properties=["name", "type"], collection_name=collection_name,
                                               url="bolt://localhost:7687", refresh_graph_schema=False)
 
@@ -96,8 +71,7 @@ def test_insert_graph_documents_and_query(monkeypatch):
         
 
 
-def test_insert_entity_and_query(monkeypatch):
-    set_env(monkeypatch)
+def test_insert_entity_and_query():
     graph_db = Neo4jLangChainWiseAgentGraphDB(properties=["name", "type"], collection_name=collection_name,
                                               url="bolt://localhost:7687", refresh_graph_schema=False)
 
@@ -115,8 +89,7 @@ def test_insert_entity_and_query(monkeypatch):
         graph_db.close()
 
 
-def test_insert_relationship_and_query(monkeypatch):
-    set_env(monkeypatch)
+def test_insert_relationship_and_query():
     graph_db = Neo4jLangChainWiseAgentGraphDB(properties=["name", "type"], collection_name=collection_name,
                                               url="bolt://localhost:7687", refresh_graph_schema=False)
 

--- a/tests/wiseagents/llm/test_WiseAgentRemoteLLM.py
+++ b/tests/wiseagents/llm/test_WiseAgentRemoteLLM.py
@@ -1,11 +1,11 @@
 import pytest
 
-from wiseagents import WiseAgentRegistry
 from wiseagents.llm import OpenaiAPIWiseAgentLLM
-
+from tests.wiseagents import assert_standard_variables_set
 
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
+    assert_standard_variables_set()
     yield
     
     

--- a/tests/wiseagents/test_WiseAgentRegistry.py
+++ b/tests/wiseagents/test_WiseAgentRegistry.py
@@ -4,10 +4,11 @@ import pytest
 
 from wiseagents import WiseAgent, WiseAgentContext, WiseAgentMessage, WiseAgentMetaData, WiseAgentRegistry, WiseAgentTransport
 from wiseagents.transports.stomp import StompWiseAgentTransport
-
+from tests.wiseagents import assert_standard_variables_set
 
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
+    assert_standard_variables_set()
     yield
     
 

--- a/tests/wiseagents/test_wise_agent_message_exchange.py
+++ b/tests/wiseagents/test_wise_agent_message_exchange.py
@@ -1,15 +1,16 @@
 import logging
-import os
 from time import sleep
 
 import pytest
 
 from wiseagents import WiseAgent, WiseAgentMessage, WiseAgentMetaData, WiseAgentRegistry
 from wiseagents.transports import StompWiseAgentTransport
+from tests.wiseagents import assert_standard_variables_set
 
 
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
+    assert_standard_variables_set()
     yield
     
     
@@ -46,10 +47,6 @@ class WiseAgentDoingNothing(WiseAgent):
 
 @pytest.mark.skip(reason="This works fine when run on its own, but fails when run with all the other tests")
 def test_send_message_to_agent_and_get_response():
-    os.environ['STOMP_USER'] = 'artemis'
-    os.environ['STOMP_PASSWORD'] = 'artemis'
-    
-    
     agent1 = WiseAgentDoingNothing('Agent1', 'Agent1')
     agent2 = WiseAgentDoingNothing('Agent2', 'Agent2')
     

--- a/tests/wiseagents/test_yaml_deserializer.py
+++ b/tests/wiseagents/test_yaml_deserializer.py
@@ -6,10 +6,11 @@ import yaml
 
 from wiseagents import WiseAgent, WiseAgentRegistry, WiseAgentMessage, WiseAgentMessageType
 from wiseagents.yaml import WiseAgentsLoader
-
+from tests.wiseagents import assert_standard_variables_set
 
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
+    assert_standard_variables_set()
     yield
     
 

--- a/tests/wiseagents/test_yaml_serializtion.py
+++ b/tests/wiseagents/test_yaml_serializtion.py
@@ -12,9 +12,11 @@ from wiseagents.graphdb import Neo4jLangChainWiseAgentGraphDB
 from wiseagents.llm import OpenaiAPIWiseAgentLLM
 from wiseagents.vectordb import PGVectorLangChainWiseAgentVectorDB
 from wiseagents.yaml import WiseAgentsLoader
+from tests.wiseagents import assert_standard_variables_set
 
 @pytest.fixture(scope="session", autouse=True)
 def run_after_all_tests():
+    assert_standard_variables_set()
     yield
 
 class DummyTransport(WiseAgentTransport):

--- a/tests/wiseagents/testing_utils.py
+++ b/tests/wiseagents/testing_utils.py
@@ -1,0 +1,23 @@
+import os
+
+def assert_standard_variables_set():
+    assert_env_vars_set(
+        "GROQ_API_KEY",
+        "NEO4J_USERNAME",
+        "NEO4J_PASSWORD",
+        "NEO4J_DATABASE",
+        "POSTGRES_USER",
+        "POSTGRES_PASSWORD",
+        "POSTGRES_DB",
+        "STOMP_USER",
+        "STOMP_PASSWORD")
+
+def assert_env_vars_set(*var_names: str):
+    for var_name in var_names:
+        assert_env_var_set(var_name)
+
+
+def assert_env_var_set(var_name: str) -> str:
+    value = os.getenv(var_name)
+    assert value, f"Need to set the {var_name} environment variable"
+    return value

--- a/tests/wiseagents/vectordb/test_PGVectorLangChainWiseAgentVectorDB.py
+++ b/tests/wiseagents/vectordb/test_PGVectorLangChainWiseAgentVectorDB.py
@@ -1,24 +1,21 @@
 import os
 
+import pytest
 from wiseagents.vectordb import Document, PGVectorLangChainWiseAgentVectorDB
+from tests.wiseagents import assert_standard_variables_set
+
+
+@pytest.fixture(scope="session", autouse=True)
+def run_after_all_tests():
+    assert_standard_variables_set()
+    yield
 
 
 def get_connection_string():
     return f"postgresql+psycopg://{os.environ['POSTGRES_USER']}:{os.environ['POSTGRES_PASSWORD']}@localhost:6024/{os.environ['POSTGRES_DB']}"
 
 
-def set_env(monkeypatch):
-    """
-        This test requires a running pgvector instance. The required
-        vector database can be started using the run_vectordb.sh script.
-    """
-    monkeypatch.setenv("POSTGRES_USER", "postgres")
-    monkeypatch.setenv("POSTGRES_PASSWORD", "postgres")
-    monkeypatch.setenv("POSTGRES_DB", "postgres")
-
-
-def test_create_and_delete_collection(monkeypatch):
-    set_env(monkeypatch)
+def test_create_and_delete_collection():
     pg_vector_db = PGVectorLangChainWiseAgentVectorDB(get_connection_string())
     pg_vector_db.get_or_create_collection("test_collection")
     assert "test_collection" in pg_vector_db._vector_dbs
@@ -26,8 +23,7 @@ def test_create_and_delete_collection(monkeypatch):
     assert "test_collection" not in pg_vector_db._vector_dbs
 
 
-def test_insert_documents_and_query(monkeypatch):
-    set_env(monkeypatch)
+def test_insert_documents_and_query():
     pg_vector_db = PGVectorLangChainWiseAgentVectorDB(get_connection_string())
 
     try:
@@ -61,8 +57,7 @@ def test_insert_documents_and_query(monkeypatch):
         pg_vector_db.delete_collection("test_collection")
 
 
-def test_insert_or_update_documents_and_query(monkeypatch):
-    set_env(monkeypatch)
+def test_insert_or_update_documents_and_query():
     pg_vector_db = PGVectorLangChainWiseAgentVectorDB(get_connection_string())
 
     try:
@@ -88,8 +83,7 @@ def test_insert_or_update_documents_and_query(monkeypatch):
         pg_vector_db.delete_collection("test_collection")
 
 
-def test_delete_documents(monkeypatch):
-    set_env(monkeypatch)
+def test_delete_documents():
     pg_vector_db = PGVectorLangChainWiseAgentVectorDB(get_connection_string())
 
     try:


### PR DESCRIPTION
Users should set these before running them.
Add coarse validation that they have done so for the most important ones

Fixes #251